### PR TITLE
chore: update plugin versions in marketplace registry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,7 +53,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with streamlined commands for creating, listing, searching, and updating issues",
-        "version": "2.2.2",
+        "version": "2.2.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -185,7 +185,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "1.1.1",
+        "version": "1.1.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": "./commands/",
   "agents": "./agents/",

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-work",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary

Update version numbers across plugins and marketplace registry to reflect recent changes.

## Changes

- **fractary-work**: 2.2.3 → 2.2.4 (added issue-refine command)
- **fractary-spec**: 1.1.1 → 1.1.2 (compatibility update)
- **marketplace.json**: synced with latest plugin versions

## Files Modified

- `.claude-plugin/marketplace.json`
- `plugins/work/.claude-plugin/plugin.json`
- `plugins/spec/.claude-plugin/plugin.json`

🤖 Generated with Claude Code