### PR TITLE
fix: correct plugin manifest agent references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -212,11 +212,10 @@
           "./commands/read.md"
         ],
         "agents": [
-          "./agents/spec-archive.md", 
+          "./agents/spec-archive.md",
           "./agents/spec-create.md",
           "./agents/spec-init.md",
           "./agents/spec-refine.md",
-          "./agents/spec-read.md",
           "./agents/spec-validate.md"
         ]
       },
@@ -250,7 +249,11 @@
           "./commands/audit.md"
         ],
         "agents": [
-          "./agents/docs-manager.md"
+          "./agents/docs-audit.md",
+          "./agents/docs-check-consistency.md",
+          "./agents/docs-list.md",
+          "./agents/docs-validate.md",
+          "./agents/docs-write.md"
         ]
       }
     ]

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -2,7 +2,13 @@
   "name": "fractary-docs",
   "version": "2.1.0",
   "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-  "agents": ["./agents/docs-manager.md"],
+  "agents": [
+    "./agents/docs-audit.md",
+    "./agents/docs-check-consistency.md",
+    "./agents/docs-list.md",
+    "./agents/docs-validate.md",
+    "./agents/docs-write.md"
+  ],
   "skills": "./skills/",
   "commands": "./commands/"
 }

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -3,6 +3,12 @@
   "version": "1.1.2",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": "./commands/",
-  "agents": "./agents/",
+  "agents": [
+    "./agents/spec-archive.md",
+    "./agents/spec-create.md",
+    "./agents/spec-init.md",
+    "./agents/spec-refine.md",
+    "./agents/spec-validate.md"
+  ],
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- Fix fractary-spec agents field from directory path to array of actual .md files
- Fix fractary-docs agents from non-existent docs-manager.md to actual agent files  
- Remove reference to non-existent spec-read.md agent
- Update marketplace.json to match actual plugin configurations

These changes resolve validation errors where plugin manifests referenced non-existent files or used incorrect path formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)