### PR TITLE
fix: specify fractary-spec plugin commands explicitly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -185,7 +185,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "1.1.2",
+        "version": "1.1.3",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,8 +1,14 @@
 {
   "name": "fractary-spec",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-  "commands": "./commands/",
+  "commands": [
+    "./commands/init.md",
+    "./commands/create.md",
+    "./commands/refine.md",
+    "./commands/validate.md",
+    "./commands/archive.md"
+  ],
   "agents": [
     "./agents/spec-archive.md",
     "./agents/spec-create.md",


### PR DESCRIPTION
## Summary
- Update fractary-spec plugin.json to explicitly list commands instead of using directory glob pattern
- This ensures all commands are properly registered and discoverable in Claude Code
- Version bumps: fractary-spec 1.1.3, marketplace 2.1.4

## Test plan
- [ ] Verify `/fractary-spec:` slash commands appear in autocomplete
- [ ] Test executing each spec command (init, create, refine, validate, archive)
- [ ] Confirm commands work in both marketplace view and general command palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)