### PR TITLE
feat: Add --context argument support to all plugin commands and agents

### DIFF
--- a/docs/plugin-development/context-argument-standard.md
+++ b/docs/plugin-development/context-argument-standard.md
@@ -1,0 +1,172 @@
+# Context Argument Standard
+
+**Standard for the `--context` argument across all Fractary Core plugin commands**
+
+## Overview
+
+All Fractary Core plugin commands support the `--context "<text>"` argument, providing users with the ability to pass additional contextual instructions to any command. This makes standardized commands more adaptable to specific circumstances or project requirements.
+
+## Specification
+
+### Argument Format
+
+```
+--context "<text>"
+```
+
+- **Position**: Always the **final optional argument** in any command
+- **Format**: Quoted string containing additional instructions
+- **Scope**: Available on ALL 41 plugin commands
+
+### Command Argument Hint Format
+
+```yaml
+# Commands with no other arguments
+argument-hint: '[--context "<text>"]'
+
+# Commands with required arguments
+argument-hint: '<required-arg> [--context "<text>"]'
+
+# Commands with optional arguments
+argument-hint: '[--optional-arg] [--context "<text>"]'
+
+# Commands with both
+argument-hint: '<required-arg> [--optional1] [--optional2] [--context "<text>"]'
+```
+
+## Agent Handling
+
+Agents that receive the `--context` argument should:
+
+1. **Parse arguments** including `--context`
+2. **Prepend context as additional instructions** to their workflow
+3. **Apply context as primary directive modifier** influencing decision-making throughout
+
+### Standard Agent Sections
+
+#### ARGUMENTS Section
+
+```markdown
+<ARGUMENTS>
+[... existing arguments ...]
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
+</ARGUMENTS>
+```
+
+#### WORKFLOW Section
+
+```markdown
+<WORKFLOW>
+1. Parse arguments (..., --context)
+2. If --context provided, apply as additional instructions to workflow
+3. [Continue with normal workflow steps]
+</WORKFLOW>
+```
+
+#### CRITICAL_RULES Section (if applicable)
+
+```markdown
+<CRITICAL_RULES>
+[... existing rules ...]
+N. With --context, prepend as additional instructions to workflow
+</CRITICAL_RULES>
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```bash
+# Add context to any command
+/fractary-docs:write api --context "Focus on error handling and include rate limiting info"
+
+/fractary-spec:create --work-id 123 --context "Prioritize security requirements"
+
+/fractary-repo:commit "Add feature" --context "Ensure conventional commit format"
+```
+
+### Context Influences Behavior
+
+```bash
+# Different contexts can adapt the same command
+/fractary-docs:validate --context "Be strict about code examples"
+/fractary-docs:validate --context "Focus on structure, ignore minor style issues"
+
+# Context guides decision-making
+/fractary-work:issue-refine --context "Emphasize performance requirements"
+```
+
+### Complex Context
+
+```bash
+# Multi-aspect context
+/fractary-spec:create --work-id 456 --context "This is a high-priority security feature. Include threat modeling section. Focus on API boundaries."
+```
+
+## Implementation Checklist
+
+When adding `--context` support to a new command or agent:
+
+### For Commands
+
+- [ ] Add `[--context "<text>"]` as final argument in `argument-hint`
+- [ ] Keep it optional (square brackets)
+- [ ] Ensure it's always last in the argument list
+
+### For Agents
+
+- [ ] Add to ARGUMENTS section with standard description
+- [ ] Add parsing step in WORKFLOW (step 1 or 2)
+- [ ] Add handling step: "If --context provided, apply as additional instructions"
+- [ ] Consider adding to CRITICAL_RULES if agent has that section
+
+## Migration from --prompt
+
+Prior to standardization, some commands used `--prompt` for similar functionality. These have been migrated to `--context` for consistency:
+
+**Migrated commands:**
+- `fractary-spec:create` (--prompt -> --context)
+- `fractary-spec:refine` (--prompt -> --context)
+- `fractary-docs:write` (--prompt -> --context)
+- `fractary-work:issue-refine` (--prompt -> --context)
+
+**Note**: `--prompt` is deprecated. All new development should use `--context`.
+
+## Design Rationale
+
+### Why "context" over "prompt"?
+
+- **Semantic clarity**: "context" better describes additional situational information
+- **Consistency**: Standardized term across all plugins
+- **Differentiation**: Distinguishes from agent "prompts" which are internal
+
+### Why always last?
+
+- **Predictability**: Users always know where to find it
+- **Parsing simplicity**: Easier argument parsing in agents
+- **Flexibility**: Can contain any text without conflicting with positional args
+
+### Why optional for all commands?
+
+- **Backward compatibility**: Existing usage patterns continue to work
+- **Flexibility**: Commands work without context but can be customized
+- **Universal applicability**: Even simple commands can benefit from context
+
+## Validation
+
+Use the validation script to verify all commands and agents have proper `--context` support:
+
+```bash
+./scripts/validate-context-support.sh
+```
+
+This script checks:
+- All commands have `--context` in argument-hint
+- All agents have `--context` in ARGUMENTS section
+- No deprecated `--prompt` references in non-archived files
+
+## Related Documentation
+
+- [Plugin Development Guide](../guides/new-claude-plugin-framework.md)
+- [Agent Development Standards](../guides/configuration.md)
+- Individual plugin READMEs for command-specific documentation

--- a/plugins/docs/README.md
+++ b/plugins/docs/README.md
@@ -719,8 +719,34 @@ service: AuthService
 - `/fractary-docs:validate [path]` - Validate documentation
 - `/fractary-docs:list [options]` - List and filter documentation
 - `/fractary-docs:audit [directory]` - Audit documentation quality
+- `/fractary-docs:check-consistency` - Check documentation consistency
 
 See individual command files in `commands/` for detailed usage.
+
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Focus validation on specific aspects
+/fractary-docs:validate --context "Be strict about code examples"
+
+# Guide documentation generation
+/fractary-docs:write api --context "Focus on error handling and include rate limiting info"
+
+# Customize audit behavior
+/fractary-docs:audit --context "Focus on structure, ignore minor style issues"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
 
 ## Integration
 

--- a/plugins/docs/agents/docs-audit.md
+++ b/plugins/docs/agents/docs-audit.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to audit documentation quality, find gaps, or identify issues.
   Use PROACTIVELY when user mentions "audit docs", "check documentation", "find doc issues", "documentation quality".
   Triggers: audit, scan, review docs, doc health, find gaps
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to audit documentation across a project - identifying issues, gaps,
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (directory, --doc-type filter)
-2. Invoke fractary-docs:doc-auditor skill
+1. Parse arguments (directory, --doc-type filter, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-docs:doc-auditor skill
 3. Scan all markdown files in target directory
 4. Classify documents by type
 5. Identify issues (missing fields, broken links, validation errors)
@@ -33,6 +35,7 @@ Your role is to audit documentation across a project - identifying issues, gaps,
 <ARGUMENTS>
 - `[directory]` - Directory to audit (default: docs/)
 - `--doc-type <type>` - Filter to specific document type
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/docs/agents/docs-check-consistency.md
+++ b/plugins/docs/agents/docs-check-consistency.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to check if documentation is consistent with code changes.
   Use PROACTIVELY when user mentions "docs out of date", "update docs", "docs consistent", "stale documentation".
   Triggers: check consistency, docs stale, sync docs, documentation drift
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to check if high-level documentation (CLAUDE.md, README.md, etc.) i
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--fix, --targets, --base, --head, --mode)
-2. Invoke fractary-docs:doc-consistency-checker skill
+1. Parse arguments (--fix, --targets, --base, --head, --mode, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-docs:doc-consistency-checker skill
 3. Analyze git diff between base and head refs
 4. Identify code changes (API, features, architecture, config)
 5. Check target documents for affected sections
@@ -37,6 +39,7 @@ Your role is to check if high-level documentation (CLAUDE.md, README.md, etc.) i
 - `--base` - Base git reference (default: main)
 - `--head` - Head git reference (default: HEAD)
 - `--mode` - Operation mode: confirm, auto, dry-run (default: confirm)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/docs/agents/docs-list.md
+++ b/plugins/docs/agents/docs-list.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to list or find documentation files.
   Use PROACTIVELY when user mentions "list docs", "find documentation", "show docs", "what docs exist".
   Triggers: list, find docs, show documentation, catalog
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to list and filter documentation files with their metadata.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (directory, --doc-type, --status, --format)
-2. Invoke fractary-docs:doc-lister skill
+1. Parse arguments (directory, --doc-type, --status, --format, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-docs:doc-lister skill
 3. Scan target directory for markdown files
 4. Extract frontmatter metadata from each file
 5. Apply filters (doc-type, status)
@@ -35,6 +37,7 @@ Your role is to list and filter documentation files with their metadata.
 - `--doc-type <type>` - Filter by document type
 - `--status <status>` - Filter by status (draft, published, deprecated)
 - `--format <format>` - Output format: table, json, markdown (default: table)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/docs/agents/docs-validate.md
+++ b/plugins/docs/agents/docs-validate.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to validate documentation against type-specific rules.
   Use PROACTIVELY when user mentions "validate docs", "check doc format", "doc errors", "lint documentation".
   Triggers: validate, check format, lint docs, verify documentation
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to validate documentation against type-specific rules and schemas.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (file_path or pattern, doc_type)
-2. Invoke fractary-docs:doc-validator skill
+1. Parse arguments (file_path or pattern, doc_type, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-docs:doc-validator skill
 3. For single file: validate against type-specific rules
 4. For pattern/directory: batch validate all matching files
 5. Check frontmatter, structure, links, schema
@@ -33,6 +35,7 @@ Your role is to validate documentation against type-specific rules and schemas.
 <ARGUMENTS>
 - `[file_path|pattern]` - File or pattern to validate (default: current directory)
 - `[doc_type]` - Document type (auto-detected if omitted)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <VALIDATION_CHECKS>

--- a/plugins/docs/agents/docs-write.md
+++ b/plugins/docs/agents/docs-write.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to create or update documentation.
   Use PROACTIVELY when user mentions "write docs", "create documentation", "document this", "add docs".
   Triggers: write, create docs, document, generate documentation
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -17,7 +18,7 @@ Your role is to create or update documentation with automatic validation and ind
 2. ALWAYS validate after writing (unless --skip-validation)
 3. ALWAYS update indices (unless --skip-index)
 4. ALWAYS use type-specific templates from types/{doc_type}/
-5. With --prompt, use conversation context to generate content
+5. With --context, prepend as additional instructions to workflow
 6. For batch mode, use docs-director-skill for parallel execution
 </CRITICAL_RULES>
 
@@ -33,7 +34,7 @@ Your role is to create or update documentation with automatic validation and ind
 <ARGUMENTS>
 - `<doc_type>` - Document type (api, adr, guide, dataset, etc.)
 - `[file_path]` - Optional path (auto-generated if omitted)
-- `--prompt "<instructions>"` - Instructions for generating from conversation context
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 - `--skip-validation` - Skip validation step
 - `--skip-index` - Skip index update
 - `--batch` - Write multiple documents (provide pattern)
@@ -51,7 +52,7 @@ Single document - invoke fractary-docs:doc-writer skill:
   "parameters": {
     "doc_type": "api",
     "file_path": null,
-    "prompt": null,
+    "context": null,
     "skip_validation": false,
     "skip_index": false
   }

--- a/plugins/docs/commands/audit.md
+++ b/plugins/docs/commands/audit.md
@@ -3,7 +3,7 @@ name: fractary-docs:audit
 description: Audit documentation - delegates to fractary-docs:docs-audit agent
 allowed-tools: Task(fractary-docs:docs-audit)
 model: claude-haiku-4-5
-argument-hint: '[directory] [--doc-type <type>]'
+argument-hint: '[directory] [--doc-type <type>] [--context "<text>"]'
 ---
 
 Delegates to fractary-docs:docs-audit agent for auditing documentation quality and finding issues.

--- a/plugins/docs/commands/check-consistency.md
+++ b/plugins/docs/commands/check-consistency.md
@@ -3,7 +3,7 @@ name: fractary-docs:check-consistency
 description: Check documentation consistency - delegates to fractary-docs:docs-check-consistency agent
 allowed-tools: Task(fractary-docs:docs-check-consistency)
 model: claude-haiku-4-5
-argument-hint: '[--fix] [--targets <files>] [--base <ref>]'
+argument-hint: '[--fix] [--targets <files>] [--base <ref>] [--context "<text>"]'
 ---
 
 Delegates to fractary-docs:docs-check-consistency agent for checking if documentation is consistent with code changes.

--- a/plugins/docs/commands/list.md
+++ b/plugins/docs/commands/list.md
@@ -3,7 +3,7 @@ name: fractary-docs:list
 description: List documentation files - delegates to fractary-docs:docs-list agent
 allowed-tools: Task(fractary-docs:docs-list)
 model: claude-haiku-4-5
-argument-hint: '[directory] [--doc-type <type>] [--status <status>] [--format <format>]'
+argument-hint: '[directory] [--doc-type <type>] [--status <status>] [--format <format>] [--context "<text>"]'
 ---
 
 Delegates to fractary-docs:docs-list agent for listing and filtering documentation files.

--- a/plugins/docs/commands/validate.md
+++ b/plugins/docs/commands/validate.md
@@ -3,7 +3,7 @@ name: fractary-docs:validate
 description: Validate documentation - delegates to fractary-docs:docs-validate agent
 allowed-tools: Task(fractary-docs:docs-validate)
 model: claude-haiku-4-5
-argument-hint: '[file_path|pattern] [doc_type]'
+argument-hint: '[file_path|pattern] [doc_type] [--context "<text>"]'
 ---
 
 Delegates to fractary-docs:docs-validate agent for validating documentation against type-specific rules.

--- a/plugins/docs/commands/write.md
+++ b/plugins/docs/commands/write.md
@@ -3,7 +3,7 @@ name: fractary-docs:write
 description: Write documentation - delegates to fractary-docs:docs-write agent
 allowed-tools: Task(fractary-docs:docs-write)
 model: claude-haiku-4-5
-argument-hint: '<doc_type> [file_path] [--prompt "<instructions>"] [--skip-validation] [--batch]'
+argument-hint: '<doc_type> [file_path] [--skip-validation] [--batch] [--context "<text>"]'
 ---
 
 Delegates to fractary-docs:docs-write agent for creating or updating documentation.

--- a/plugins/file/README.md
+++ b/plugins/file/README.md
@@ -316,6 +316,31 @@ Stream file contents without downloading (NEW).
 **Use Cases**: Read archived specs, logs, configs without downloading.
 **Limits**: Default 10MB, max 50MB. Files larger should be downloaded.
 
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Guide initialization
+/fractary-file:init --context "Configure for high-availability production use"
+
+# Customize connection testing
+/fractary-file:test-connection --context "Verify with verbose output"
+
+# Adjust handler selection
+/fractary-file:show-config --context "Focus on S3 configuration details"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
+
 ## Configuration
 
 Configuration is stored in `.fractary/plugins/file/config.json`.

--- a/plugins/file/agents/file-init.md
+++ b/plugins/file/agents/file-init.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to initialize or configure the file storage plugin.
   Use PROACTIVELY when user mentions "init file", "setup storage", "configure file plugin".
   Triggers: init, initialize, setup, configure file storage
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to initialize and configure the file plugin with storage handlers.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--handlers, --non-interactive, --test)
-2. Display welcome banner
+1. Parse arguments (--handlers, --non-interactive, --test, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Display welcome banner
 3. Invoke fractary-file:config-wizard skill
 4. Run configuration wizard for each handler
 5. Test connections
@@ -34,6 +36,7 @@ Your role is to initialize and configure the file plugin with storage handlers.
 - `--non-interactive` - Skip prompts, use defaults or environment variables
 - `--test` - Test connection after configuration (default: true)
 - `--no-test` - Skip connection test
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SUPPORTED_HANDLERS>

--- a/plugins/file/agents/file-show-config.md
+++ b/plugins/file/agents/file-show-config.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to view file plugin configuration.
   Use PROACTIVELY when user mentions "show config", "view storage config", "file settings".
   Triggers: show config, view config, display settings
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to display the current configuration with sensitive values masked.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--raw, --path, --verify)
-2. Locate configuration file (project or global)
+1. Parse arguments (--raw, --path, --verify, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Locate configuration file (project or global)
 3. Load and validate configuration
 4. Mask sensitive values
 5. Display formatted output
@@ -32,6 +34,7 @@ Your role is to display the current configuration with sensitive values masked.
 - `--raw` - Show raw JSON (still with masked credentials)
 - `--path` - Only show configuration file path
 - `--verify` - Verify configuration is valid
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <CONFIG_LOCATIONS>

--- a/plugins/file/agents/file-switch-handler.md
+++ b/plugins/file/agents/file-switch-handler.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to switch the active storage handler.
   Use PROACTIVELY when user mentions "switch handler", "change storage", "use S3", "use local".
   Triggers: switch handler, change storage, use different provider
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to switch the active storage handler to a different configured prov
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (handler, --no-test, --force)
-2. Locate configuration file
+1. Parse arguments (handler, --no-test, --force, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Locate configuration file
 3. Verify target handler is configured
 4. Create backup of current configuration
 5. Update active_handler field
@@ -35,6 +37,7 @@ Your role is to switch the active storage handler to a different configured prov
 - `<handler>` - Handler name to switch to (required): local|r2|s3|gcs|gdrive
 - `--no-test` - Skip connection test after switching
 - `--force` - Switch even if handler appears unconfigured
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <VALID_HANDLERS>

--- a/plugins/file/agents/file-test-connection.md
+++ b/plugins/file/agents/file-test-connection.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to test file storage connection.
   Use PROACTIVELY when user mentions "test connection", "verify storage", "check file access".
   Triggers: test connection, verify, check storage, test upload
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to test the current file plugin configuration by verifying connecti
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--handler, --verbose, --quick)
-2. Load configuration
+1. Parse arguments (--handler, --verbose, --quick, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Load configuration
 3. Run pre-flight checks (CLI tools, credentials, bucket)
 4. Perform connection test (list operation)
 5. Run extended checks (unless --quick)
@@ -33,6 +35,7 @@ Your role is to test the current file plugin configuration by verifying connecti
 - `--handler <name>` - Test specific handler instead of active one
 - `--verbose` - Show detailed connection information
 - `--quick` - Skip extended checks, just test basic connectivity
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <PRE_FLIGHT_CHECKS>

--- a/plugins/file/commands/init.md
+++ b/plugins/file/commands/init.md
@@ -3,7 +3,7 @@ name: fractary-file:init
 description: Initialize file plugin - delegates to fractary-file:file-init agent
 allowed-tools: Task(fractary-file:file-init)
 model: claude-haiku-4-5
-argument-hint: '[--handlers <providers>] [--non-interactive] [--no-test]'
+argument-hint: '[--handlers <providers>] [--non-interactive] [--no-test] [--context "<text>"]'
 ---
 
 Delegates to fractary-file:file-init agent for initializing and configuring file storage.

--- a/plugins/file/commands/show-config.md
+++ b/plugins/file/commands/show-config.md
@@ -3,7 +3,7 @@ name: fractary-file:show-config
 description: Show file plugin configuration - delegates to fractary-file:file-show-config agent
 allowed-tools: Task(fractary-file:file-show-config)
 model: claude-haiku-4-5
-argument-hint: '[--raw] [--path] [--verify]'
+argument-hint: '[--raw] [--path] [--verify] [--context "<text>"]'
 ---
 
 Delegates to fractary-file:file-show-config agent for displaying current configuration.

--- a/plugins/file/commands/switch-handler.md
+++ b/plugins/file/commands/switch-handler.md
@@ -3,7 +3,7 @@ name: fractary-file:switch-handler
 description: Switch storage handler - delegates to fractary-file:file-switch-handler agent
 allowed-tools: Task(fractary-file:file-switch-handler)
 model: claude-haiku-4-5
-argument-hint: '<handler> [--no-test] [--force]'
+argument-hint: '<handler> [--no-test] [--force] [--context "<text>"]'
 ---
 
 Delegates to fractary-file:file-switch-handler agent for switching active storage handler.

--- a/plugins/file/commands/test-connection.md
+++ b/plugins/file/commands/test-connection.md
@@ -3,7 +3,7 @@ name: fractary-file:test-connection
 description: Test storage connection - delegates to fractary-file:file-test-connection agent
 allowed-tools: Task(fractary-file:file-test-connection)
 model: claude-haiku-4-5
-argument-hint: '[--handler <name>] [--verbose] [--quick]'
+argument-hint: '[--handler <name>] [--verbose] [--quick] [--context "<text>"]'
 ---
 
 Delegates to fractary-file:file-test-connection agent for testing storage connectivity.

--- a/plugins/logs/README.md
+++ b/plugins/logs/README.md
@@ -184,6 +184,31 @@ Archive logs for completed issue to cloud.
 
 - `/fractary-logs:init` - Initialize configuration
 
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Guide log capture focus
+/fractary-logs:capture 123 --context "Focus on API integration decisions"
+
+# Customize search behavior
+/fractary-logs:search "error" --context "Include full stack traces in results"
+
+# Focus analysis on specific areas
+/fractary-logs:analyze errors --context "Prioritize authentication-related errors"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
+
 ## Features
 
 ### Session Capture

--- a/plugins/logs/agents/logs-analyze.md
+++ b/plugins/logs/agents/logs-analyze.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to analyze logs for patterns, errors, or time spent.
   Use PROACTIVELY when user mentions "analyze logs", "find errors", "log patterns", "time analysis".
   Triggers: analyze, errors, patterns, time spent, summarize logs
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to analyze logs for patterns, errors, summaries, or time analysis.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (type, --issue, --since, --until, --verbose)
-2. Invoke fractary-logs:log-analyzer skill
+1. Parse arguments (type, --issue, --since, --until, --verbose, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-analyzer skill
 3. Load logs based on filters
 4. Perform analysis by type
 5. Format and return results
@@ -34,6 +36,7 @@ Your role is to analyze logs for patterns, errors, summaries, or time analysis.
 - `--since <date>` - Start date (YYYY-MM-DD)
 - `--until <date>` - End date (YYYY-MM-DD)
 - `--verbose` - Show detailed breakdown
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <ANALYSIS_TYPES>

--- a/plugins/logs/agents/logs-archive.md
+++ b/plugins/logs/agents/logs-archive.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to archive logs for a completed issue to cloud storage.
   Use PROACTIVELY when user mentions "archive logs", "backup logs", "store logs in cloud".
   Triggers: archive, backup, cloud storage, preserve logs
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to archive all logs for a completed issue to cloud storage.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (issue_number, --force, --retry)
-2. Invoke fractary-logs:log-archiver skill
+1. Parse arguments (issue_number, --force, --retry, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-archiver skill
 3. Collect all logs for issue
 4. Compress large files
 5. Upload to cloud via fractary-file
@@ -35,6 +37,7 @@ Your role is to archive all logs for a completed issue to cloud storage.
 - `<issue_number>` - GitHub issue number (required)
 - `--force` - Skip checks and force re-archive
 - `--retry` - Retry failed uploads from partial archive
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/agents/logs-audit.md
+++ b/plugins/logs/agents/logs-audit.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to audit logs in project and generate management plan.
   Use PROACTIVELY when user mentions "audit logs", "log health check", "find unmanaged logs", "log compliance".
   Triggers: audit, health check, compliance, log management
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to audit existing logs in a project, identify what should be manage
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--project-root, --execute)
-2. Invoke fractary-logs:log-auditor skill
+1. Parse arguments (--project-root, --execute, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-auditor skill
 3. Load configuration and .gitignore patterns
 4. Discover all log files and log-like files
 5. Analyze against best practices
@@ -35,6 +37,7 @@ Your role is to audit existing logs in a project, identify what should be manage
 <ARGUMENTS>
 - `--project-root <path>` - Root directory to audit (default: current directory)
 - `--execute` - Execute high-priority remediations immediately
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <OUTPUTS>

--- a/plugins/logs/agents/logs-capture.md
+++ b/plugins/logs/agents/logs-capture.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to start capturing a conversation session for an issue.
   Use PROACTIVELY when user mentions "start logging", "capture session", "record conversation".
   Triggers: capture, start session, begin logging, record
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to start capturing Claude Code conversation sessions for an issue.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (issue_number)
-2. Invoke fractary-logs:log-capturer skill
+1. Parse arguments (issue_number, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-capturer skill
 3. Check for old logs (auto-backup if enabled)
 4. Create session log file
 5. Initialize with frontmatter (issue, timestamps, participant)
@@ -32,6 +34,7 @@ Your role is to start capturing Claude Code conversation sessions for an issue.
 
 <ARGUMENTS>
 - `<issue_number>` - GitHub issue number to link session to (required)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/agents/logs-cleanup.md
+++ b/plugins/logs/agents/logs-cleanup.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to clean up old logs based on age threshold.
   Use PROACTIVELY when user mentions "cleanup logs", "remove old logs", "free space".
   Triggers: cleanup, clean, remove old, free space
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to archive and clean up old logs based on age thresholds.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--older-than, --dry-run)
-2. Invoke fractary-logs:log-archiver skill with cleanup operation
+1. Parse arguments (--older-than, --dry-run, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-archiver skill with cleanup operation
 3. Find logs older than threshold
 4. Group by issue number
 5. Archive unarchived logs
@@ -34,6 +36,7 @@ Your role is to archive and clean up old logs based on age thresholds.
 <ARGUMENTS>
 - `--older-than <days>` - Age threshold in days (default: 30)
 - `--dry-run` - Show what would be done without doing it
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/agents/logs-init.md
+++ b/plugins/logs/agents/logs-init.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to initialize or configure the logs plugin.
   Use PROACTIVELY when user mentions "init logs", "setup logging", "configure logs".
   Triggers: init, initialize, setup, configure logs
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to initialize the fractary-logs plugin configuration and storage di
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--force)
-2. Create `.fractary/plugins/logs/` directory
+1. Parse arguments (--force, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Create `.fractary/plugins/logs/` directory
 3. Copy config.json from plugin example
 4. Create log storage directories (/logs/sessions, /logs/builds, etc.)
 5. Initialize archive index
@@ -33,6 +35,7 @@ Your role is to initialize the fractary-logs plugin configuration and storage di
 
 <ARGUMENTS>
 - `--force` - Overwrite existing configuration
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <DIRECTORIES_CREATED>

--- a/plugins/logs/agents/logs-log.md
+++ b/plugins/logs/agents/logs-log.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to log a specific message or decision to an issue's log.
   Use PROACTIVELY when user mentions "log message", "record decision", "add to log".
   Triggers: log, record, add entry, note
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to log specific messages or decisions to an issue's log.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (issue_number, message)
-2. Invoke fractary-logs:log-writer skill
+1. Parse arguments (issue_number, message, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-writer skill
 3. Check for active session
 4. Append message with timestamp
 5. Link to issue
@@ -32,6 +34,7 @@ Your role is to log specific messages or decisions to an issue's log.
 <ARGUMENTS>
 - `<issue_number>` - GitHub issue number (required)
 - `<message>` - Message to log (required, use quotes for multi-word)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/agents/logs-read.md
+++ b/plugins/logs/agents/logs-read.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to read log files for an issue.
   Use PROACTIVELY when user mentions "read logs", "show logs", "view log", "get logs".
   Triggers: read, show, view, display logs
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to read specific log files (local or archived) for an issue.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (issue_number, --type)
-2. Invoke fractary-logs:log-lister skill
+1. Parse arguments (issue_number, --type, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-lister skill
 3. Check archive index for location
 4. If local: read directly
 5. If archived: use fractary-file to read from cloud
@@ -33,6 +35,7 @@ Your role is to read specific log files (local or archived) for an issue.
 <ARGUMENTS>
 - `<issue_number>` - GitHub issue number (required)
 - `--type <type>` - Specific log type: session, build, deployment, debug
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/agents/logs-search.md
+++ b/plugins/logs/agents/logs-search.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to search across logs.
   Use PROACTIVELY when user mentions "search logs", "find in logs", "grep logs".
   Triggers: search, find, grep, look for
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to search across local and archived logs with filters.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (query, filters, options)
-2. Invoke fractary-logs:log-searcher skill
+1. Parse arguments (query, filters, options, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-searcher skill
 3. Search local logs (fast)
 4. Search cloud logs via index if enabled
 5. Aggregate and rank results
@@ -39,7 +41,8 @@ Your role is to search across local and archived logs with filters.
 - `--local-only` - Search only local logs
 - `--cloud-only` - Search only archived logs
 - `--max-results <n>` - Limit results (default: 100)
-- `--context <n>` - Lines of context (default: 3)
+- `--context-lines <n>` - Lines of context around matches (default: 3)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/agents/logs-stop.md
+++ b/plugins/logs/agents/logs-stop.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to stop active session capture.
   Use PROACTIVELY when user mentions "stop logging", "end session", "finish capture".
   Triggers: stop, end, finish, complete session
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,10 @@ Your role is to stop the active session capture and finalize the log.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Invoke fractary-logs:log-capturer skill with stop operation
-2. Update session file with completion info
+1. Parse arguments (--context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-logs:log-capturer skill with stop operation
+4. Update session file with completion info
 3. Calculate and record duration
 4. Generate session summary
 5. Clear active session context
@@ -30,7 +33,7 @@ Your role is to stop the active session capture and finalize the log.
 </WORKFLOW>
 
 <ARGUMENTS>
-No arguments required.
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <SKILL_INVOCATION>

--- a/plugins/logs/commands/analyze.md
+++ b/plugins/logs/commands/analyze.md
@@ -3,7 +3,7 @@ name: fractary-logs:analyze
 description: Analyze logs - delegates to fractary-logs:logs-analyze agent
 allowed-tools: Task(fractary-logs:logs-analyze)
 model: claude-haiku-4-5
-argument-hint: '<type> [--issue <number>] [--since <date>] [--until <date>] [--verbose]'
+argument-hint: '<type> [--issue <number>] [--since <date>] [--until <date>] [--verbose] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-analyze agent for analyzing logs for patterns, errors, summaries, or time analysis.

--- a/plugins/logs/commands/archive.md
+++ b/plugins/logs/commands/archive.md
@@ -3,7 +3,7 @@ name: fractary-logs:archive
 description: Archive logs - delegates to fractary-logs:logs-archive agent
 allowed-tools: Task(fractary-logs:logs-archive)
 model: claude-haiku-4-5
-argument-hint: '<issue_number> [--force] [--retry]'
+argument-hint: '<issue_number> [--force] [--retry] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-archive agent for archiving issue logs to cloud storage.

--- a/plugins/logs/commands/audit.md
+++ b/plugins/logs/commands/audit.md
@@ -3,7 +3,7 @@ name: fractary-logs:audit
 description: Audit logs - delegates to fractary-logs:logs-audit agent
 allowed-tools: Task(fractary-logs:logs-audit)
 model: claude-haiku-4-5
-argument-hint: '[--project-root <path>] [--execute]'
+argument-hint: '[--project-root <path>] [--execute] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-audit agent for auditing logs and generating management plans.

--- a/plugins/logs/commands/capture.md
+++ b/plugins/logs/commands/capture.md
@@ -3,7 +3,7 @@ name: fractary-logs:capture
 description: Capture session - delegates to fractary-logs:logs-capture agent
 allowed-tools: Task(fractary-logs:logs-capture)
 model: claude-haiku-4-5
-argument-hint: '<issue_number>'
+argument-hint: '<issue_number> [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-capture agent for starting conversation session capture.

--- a/plugins/logs/commands/cleanup.md
+++ b/plugins/logs/commands/cleanup.md
@@ -3,7 +3,7 @@ name: fractary-logs:cleanup
 description: Cleanup logs - delegates to fractary-logs:logs-cleanup agent
 allowed-tools: Task(fractary-logs:logs-cleanup)
 model: claude-haiku-4-5
-argument-hint: '[--older-than <days>] [--dry-run]'
+argument-hint: '[--older-than <days>] [--dry-run] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-cleanup agent for archiving and cleaning up old logs.

--- a/plugins/logs/commands/init.md
+++ b/plugins/logs/commands/init.md
@@ -3,7 +3,7 @@ name: fractary-logs:init
 description: Initialize logs plugin - delegates to fractary-logs:logs-init agent
 allowed-tools: Task(fractary-logs:logs-init)
 model: claude-haiku-4-5
-argument-hint: '[--force]'
+argument-hint: '[--force] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-init agent for initializing plugin configuration and storage.

--- a/plugins/logs/commands/log.md
+++ b/plugins/logs/commands/log.md
@@ -3,7 +3,7 @@ name: fractary-logs:log
 description: Log message - delegates to fractary-logs:logs-log agent
 allowed-tools: Task(fractary-logs:logs-log)
 model: claude-haiku-4-5
-argument-hint: '<issue_number> "<message>"'
+argument-hint: '<issue_number> "<message>" [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-log agent for logging messages to an issue's log.

--- a/plugins/logs/commands/read.md
+++ b/plugins/logs/commands/read.md
@@ -3,7 +3,7 @@ name: fractary-logs:read
 description: Read logs - delegates to fractary-logs:logs-read agent
 allowed-tools: Task(fractary-logs:logs-read)
 model: claude-haiku-4-5
-argument-hint: '<issue_number> [--type <type>]'
+argument-hint: '<issue_number> [--type <type>] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-read agent for reading log files.

--- a/plugins/logs/commands/search.md
+++ b/plugins/logs/commands/search.md
@@ -3,7 +3,7 @@ name: fractary-logs:search
 description: Search logs - delegates to fractary-logs:logs-search agent
 allowed-tools: Task(fractary-logs:logs-search)
 model: claude-haiku-4-5
-argument-hint: '"<query>" [--issue <number>] [--type <type>] [--since <date>]'
+argument-hint: '"<query>" [--issue <number>] [--type <type>] [--since <date>] [--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-search agent for searching across logs.

--- a/plugins/logs/commands/stop.md
+++ b/plugins/logs/commands/stop.md
@@ -3,7 +3,7 @@ name: fractary-logs:stop
 description: Stop session - delegates to fractary-logs:logs-stop agent
 allowed-tools: Task(fractary-logs:logs-stop)
 model: claude-haiku-4-5
-argument-hint: ''
+argument-hint: '[--context "<text>"]'
 ---
 
 Delegates to fractary-logs:logs-stop agent for stopping active session capture.

--- a/plugins/repo/README.md
+++ b/plugins/repo/README.md
@@ -329,6 +329,31 @@ Clean up stale and merged branches.
 
 [Full documentation](commands/cleanup.md)
 
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Guide commit message style
+/fractary-repo:commit "Add feature" --context "Ensure conventional commit format with scope"
+
+# Customize PR creation
+/fractary-repo:pr-create --context "Include performance impact section in PR body"
+
+# Focus branch naming
+/fractary-repo:init --context "Use company-specific branch naming conventions"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
+
 ## Programmatic Usage
 
 The plugin can be invoked programmatically by other plugins or FABER workflows:

--- a/plugins/repo/agents/init.md
+++ b/plugins/repo/agents/init.md
@@ -2,6 +2,7 @@
 name: fractary-repo:init
 description: Initialize and configure the repo plugin for GitHub, GitLab, or Bitbucket MUST BE USED for all init operations from fractary-repo:init command. Use PROACTIVELY when user requests init operations.
 tools: fractary_repo_status
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -31,11 +32,22 @@ Interactive setup wizard for configuring the repo plugin with platform detection
 | token | string | No | API token (prompted if not provided) |
 | yes | boolean | No | Skip confirmation prompts |
 | force | boolean | No | Overwrite existing configuration |
+| context | string | No | Additional instructions prepended to workflow |
+
+<ARGUMENTS>
+- `--platform <name>` - Platform: github, gitlab, bitbucket (auto-detected if not provided)
+- `--token <value>` - API token (prompted if not provided)
+- `--yes` - Skip confirmation prompts
+- `--force` - Overwrite existing configuration
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
+</ARGUMENTS>
 
 ## Workflow
 
 <WORKFLOW>
-1. Check for existing configuration:
+1. Parse arguments (--platform, --token, --yes, --force, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Check for existing configuration:
    - If exists and not force, ask to overwrite
 
 2. Detect platform if not specified:

--- a/plugins/repo/archived/agents/pr-create.md
+++ b/plugins/repo/archived/agents/pr-create.md
@@ -2,6 +2,7 @@
 name: fractary-repo:pr-create
 description: Create pull requests with intelligent title and body generation from git context. MUST BE USED for all pr-create operations from fractary-repo:pr-create command. Use PROACTIVELY when user requests pr create operations. Self-sufficient - drafts content from conversation context or git changes.
 tools: fractary_repo_pr_create, fractary_repo_branch_current, fractary_repo_diff, fractary_repo_commit_log
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/repo/archived/agents/pr-merge.md
+++ b/plugins/repo/archived/agents/pr-merge.md
@@ -2,6 +2,7 @@
 name: fractary-repo:pr-merge
 description: Merge pull requests with configurable merge strategy MUST BE USED for all pr-merge operations from fractary-repo:pr-merge command. Use PROACTIVELY when user requests pr merge operations.
 tools: fractary_repo_pr_merge, fractary_repo_pr_get, fractary_repo_worktree_remove
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/repo/archived/agents/pr-review.md
+++ b/plugins/repo/archived/agents/pr-review.md
@@ -2,6 +2,7 @@
 name: fractary-repo:pr-review
 description: Review pull requests with approve, request changes, or comment actions MUST BE USED for all pr-review operations from fractary-repo:pr-review command. Use PROACTIVELY when user requests pr review operations.
 tools: fractary_repo_pr_review, fractary_repo_pr_get, fractary_repo_diff
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/repo/archived/agents/pull.md
+++ b/plugins/repo/archived/agents/pull.md
@@ -2,6 +2,7 @@
 name: fractary-repo:pull
 description: Pull branches from remote repository with merge or rebase options. MUST BE USED for all pull operations from fractary-repo:pull command. Use PROACTIVELY when user requests pulling branches.
 tools: fractary_repo_pull, fractary_repo_branch_current
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/repo/archived/agents/repo-manager.md
+++ b/plugins/repo/archived/agents/repo-manager.md
@@ -2,6 +2,7 @@
 name: repo-manager
 description: Universal source control agent - routes repository operations to specialized skills
 tools: Bash, Skill
+color: orange
 model: claude-opus-4-5
 color: orange
 ---

--- a/plugins/repo/commands/commit-push-pr.md
+++ b/plugins/repo/commands/commit-push-pr.md
@@ -2,6 +2,7 @@
 allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
 description: Commit, push, and open a PR
 model: claude-haiku-4-5
+argument-hint: '[--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/repo/commands/commit-push.md
+++ b/plugins/repo/commands/commit-push.md
@@ -3,6 +3,7 @@ name: fractary-repo:commit-push
 allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*)
 description: Commit and push
 model: claude-haiku-4-5
+argument-hint: '[--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/repo/commands/commit.md
+++ b/plugins/repo/commands/commit.md
@@ -3,6 +3,7 @@ name: fractary-repo:commit
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
 description: Commit, push, and open a PR
 model: claude-haiku-4-5
+argument-hint: '[--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/repo/commands/init.md
+++ b/plugins/repo/commands/init.md
@@ -3,7 +3,7 @@ name: fractary-repo:init
 description: Initialize repo plugin - delegates to fractary-repo:init agent
 allowed-tools: Task(fractary-repo:init)
 model: claude-haiku-4-5
-argument-hint: '[--platform <name>] [--token <value>] [--yes] [--force]'
+argument-hint: '[--platform <name>] [--token <value>] [--yes] [--force] [--context "<text>"]'
 ---
 
 Delegates to fractary-repo:init agent for repo plugin setup.

--- a/plugins/repo/commands/pr-create.md
+++ b/plugins/repo/commands/pr-create.md
@@ -2,7 +2,7 @@
 allowed-tools: Bash(gh pr create:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*)
 description: Create pull requests
 model: claude-haiku-4-5
-argument-hint: '[--title "<title>"] [--body "<body>"] [--draft] [--base <branch>]'
+argument-hint: '[--title "<title>"] [--body "<body>"] [--draft] [--base <branch>] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/repo/commands/pr-merge.md
+++ b/plugins/repo/commands/pr-merge.md
@@ -2,7 +2,7 @@
 allowed-tools: Bash(gh pr merge:*), Bash(gh pr view:*)
 description: Merge pull requests
 model: claude-haiku-4-5
-argument-hint: '<pr_number> [--squash|--merge|--rebase] [--delete-branch]'
+argument-hint: '<pr_number> [--squash|--merge|--rebase] [--delete-branch] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/repo/commands/pr-review.md
+++ b/plugins/repo/commands/pr-review.md
@@ -2,7 +2,7 @@
 allowed-tools: Bash(gh pr review:*), Bash(gh pr view:*), Bash(gh pr diff:*)
 description: Review pull requests
 model: claude-haiku-4-5
-argument-hint: '<pr_number> [--approve|--request-changes|--comment] [--body "<text>"]'
+argument-hint: '<pr_number> [--approve|--request-changes|--comment] [--body "<text>"] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/repo/commands/pull.md
+++ b/plugins/repo/commands/pull.md
@@ -2,7 +2,7 @@
 allowed-tools: Bash(git pull:*), Bash(git status:*)
 description: Pull branches from remote
 model: claude-haiku-4-5
-argument-hint: '[--rebase] [--remote <name>]'
+argument-hint: '[--rebase] [--remote <name>] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/spec/README.md
+++ b/plugins/spec/README.md
@@ -154,6 +154,31 @@ Streams from cloud without local download.
 | `/fractary-spec:archive <issue>` | Archive to cloud |
 | `/fractary-spec:read <issue>` | Read archived spec |
 
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Guide spec creation
+/fractary-spec:create --work-id 123 --context "Prioritize security requirements"
+
+# Focus validation
+/fractary-spec:validate 123 --context "Emphasize test coverage requirements"
+
+# Customize refinement
+/fractary-spec:refine 123 --context "Focus on API design and error handling"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
+
 ### Key Features of `create`
 
 - **Auto-Detection**: Automatically detects issue ID from current branch name (via repo plugin)

--- a/plugins/spec/agents/spec-archive.md
+++ b/plugins/spec/agents/spec-archive.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to archive specifications for completed work.
   Use PROACTIVELY when user mentions "archive spec", "completed work", "close issue with spec".
   Triggers: archive, complete, close issue, upload spec
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to archive specifications to cloud storage when work is complete.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (issue_number, --force, --skip-warnings)
-2. Invoke fractary-spec:spec-archiver skill
+1. Parse arguments (issue_number, --force, --skip-warnings, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-spec:spec-archiver skill
 3. Find all specs for issue
 4. Check pre-archive conditions
 5. Upload to cloud storage
@@ -36,6 +38,7 @@ Your role is to archive specifications to cloud storage when work is complete.
 - `<issue_number>` - GitHub issue number (required)
 - `--force` - Skip all pre-archive checks
 - `--skip-warnings` - Don't prompt for warnings
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <PRE_ARCHIVE_CHECKS>

--- a/plugins/spec/agents/spec-create.md
+++ b/plugins/spec/agents/spec-create.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to create a specification from conversation context.
   Use PROACTIVELY when user mentions "create spec", "write spec", "document requirements".
   Triggers: create spec, generate spec, write specification
+color: orange
 model: claude-opus-4-5
 ---
 
@@ -21,7 +22,7 @@ Your role is to create specifications from conversation context, optionally enri
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--work-id, --template, --prompt, --force)
+1. Parse arguments (--work-id, --template, --context, --force)
 2. Auto-detect work-id from branch if not provided
 3. Check for existing specs (skip if exists unless --force)
 4. Invoke fractary-spec:spec-generator skill
@@ -35,7 +36,7 @@ Your role is to create specifications from conversation context, optionally enri
 <ARGUMENTS>
 - `--work-id <id>` - Optional: Link to issue and enrich with issue data
 - `--template <type>` - Optional: Override auto-detection (basic|feature|infrastructure|api|bug)
-- `--prompt "<instructions>"` - Optional: Instructions for generation
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 - `--force` - Force creation even if spec exists
 </ARGUMENTS>
 
@@ -52,7 +53,7 @@ Invoke the fractary-spec:spec-generator skill with:
   "parameters": {
     "work_id": "123",
     "template": null,
-    "prompt": null,
+    "context": null,
     "force": false
   }
 }

--- a/plugins/spec/agents/spec-init.md
+++ b/plugins/spec/agents/spec-init.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to initialize or configure the spec plugin.
   Use PROACTIVELY when user mentions "init spec", "setup spec plugin", "configure specs".
   Triggers: init, initialize, setup spec plugin
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,10 @@ Your role is to initialize the fractary-spec plugin configuration in the current
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Copy config.example.json to project config location
-2. Create /specs directory
+1. Parse arguments (--force, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Copy config.example.json to project config location
+4. Create /specs directory
 3. Initialize archive index:
    - Local cache: `.fractary/plugins/spec/archive-index.json`
    - Cloud backup: `archive/specs/.archive-index.json`
@@ -33,6 +36,7 @@ Your role is to initialize the fractary-spec plugin configuration in the current
 
 <ARGUMENTS>
 - `--force` - Overwrite existing configuration
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <DIRECTORIES_CREATED>

--- a/plugins/spec/agents/spec-refine.md
+++ b/plugins/spec/agents/spec-refine.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to critically review and improve a specification.
   Use PROACTIVELY when user mentions "refine spec", "improve spec", "review specification".
   Triggers: refine, improve, review, clarify spec
+color: orange
 model: claude-opus-4-5
 ---
 
@@ -21,7 +22,7 @@ Your role is to critically review and refine existing specifications through int
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (--work-id, --prompt)
+1. Parse arguments (--work-id, --context)
 2. Invoke fractary-spec:spec-refiner skill
 3. Load spec for work-id
 4. Perform critical analysis
@@ -36,7 +37,7 @@ Your role is to critically review and refine existing specifications through int
 
 <ARGUMENTS>
 - `--work-id <id>` - Required: Work item ID whose spec to refine
-- `--prompt "<focus>"` - Optional: Focus refinement on specific areas
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <QUESTION_QUALITY>
@@ -54,7 +55,7 @@ Invoke the fractary-spec:spec-refiner skill with:
   "operation": "refine",
   "parameters": {
     "work_id": "255",
-    "prompt": null
+    "context": null
   }
 }
 ```

--- a/plugins/spec/agents/spec-validate.md
+++ b/plugins/spec/agents/spec-validate.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to validate implementation against specification.
   Use PROACTIVELY when user mentions "validate spec", "check implementation", "verify requirements".
   Triggers: validate, verify, check implementation, acceptance criteria
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -21,8 +22,9 @@ Your role is to validate that implementation matches specification requirements.
 </CRITICAL_RULES>
 
 <WORKFLOW>
-1. Parse arguments (issue_number, --phase)
-2. Invoke fractary-spec:spec-validator skill
+1. Parse arguments (issue_number, --phase, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Invoke fractary-spec:spec-validator skill
 3. Load spec for issue
 4. Check requirements coverage
 5. Check acceptance criteria
@@ -37,6 +39,7 @@ Your role is to validate that implementation matches specification requirements.
 <ARGUMENTS>
 - `<issue_number>` - GitHub issue number (required)
 - `--phase <n>` - Validate specific phase for multi-spec issues
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
 </ARGUMENTS>
 
 <VALIDATION_CHECKS>

--- a/plugins/spec/commands/archive.md
+++ b/plugins/spec/commands/archive.md
@@ -3,7 +3,7 @@ name: fractary-spec:archive
 description: Archive specifications - delegates to fractary-spec:spec-archive agent
 allowed-tools: Task(fractary-spec:spec-archive)
 model: claude-haiku-4-5
-argument-hint: '<issue_number> [--force] [--skip-warnings]'
+argument-hint: '<issue_number> [--force] [--skip-warnings] [--context "<text>"]'
 ---
 
 Delegates to fractary-spec:spec-archive agent for archiving completed specifications to cloud storage.

--- a/plugins/spec/commands/create.md
+++ b/plugins/spec/commands/create.md
@@ -3,7 +3,7 @@ name: fractary-spec:create
 description: Create specification - delegates to fractary-spec:spec-create agent
 allowed-tools: Task(fractary-spec:spec-create)
 model: claude-opus-4-5
-argument-hint: '[--work-id <id>] [--template <type>] [--prompt "<instructions>"] [--force]'
+argument-hint: '[--work-id <id>] [--template <type>] [--force] [--context "<text>"]'
 ---
 
 Use **Task** tool with `fractary-spec:spec-create` agent to create specification from conversational context and provided arguments.

--- a/plugins/spec/commands/init.md
+++ b/plugins/spec/commands/init.md
@@ -3,7 +3,7 @@ name: fractary-spec:init
 description: Initialize spec plugin - delegates to fractary-spec:spec-init agent
 allowed-tools: Task(fractary-spec:spec-init)
 model: claude-haiku-4-5
-argument-hint: '[--force]'
+argument-hint: '[--force] [--context "<text>"]'
 ---
 
 Delegates to fractary-spec:spec-init agent for initializing plugin configuration.

--- a/plugins/spec/commands/refine.md
+++ b/plugins/spec/commands/refine.md
@@ -3,7 +3,7 @@ name: fractary-spec:refine
 description: Refine specification - delegates to fractary-spec:spec-refine agent
 allowed-tools: Task(fractary-spec:spec-refine)
 model: claude-opus-4-5
-argument-hint: '--work-id <id> [--prompt "<focus>"]'
+argument-hint: '--work-id <id> [--context "<text>"]'
 ---
 
 Delegates to fractary-spec:spec-refine agent for critically reviewing and refining specifications.

--- a/plugins/spec/commands/validate.md
+++ b/plugins/spec/commands/validate.md
@@ -3,7 +3,7 @@ name: fractary-spec:validate
 description: Validate specification - delegates to fractary-spec:spec-validate agent
 allowed-tools: Task(fractary-spec:spec-validate)
 model: claude-haiku-4-5
-argument-hint: '<issue_number> [--phase <n>]'
+argument-hint: '<issue_number> [--phase <n>] [--context "<text>"]'
 ---
 
 Delegates to fractary-spec:spec-validate agent for validating implementation against specification.

--- a/plugins/status/README.md
+++ b/plugins/status/README.md
@@ -39,6 +39,28 @@ last: update spec accordingly
 last: /fractary-spec:generate 99
 ```
 
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Guide installation with specific preferences
+/fractary-status:install --context "Enable verbose output during installation"
+
+# Customize sync behavior
+/fractary-status:sync --context "Force full refresh of all cached data"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
+
 ## Installation
 
 ### Quick Install

--- a/plugins/status/agents/status-install.md
+++ b/plugins/status/agents/status-install.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to install or set up the Fractary status line plugin in their project.
   Use PROACTIVELY when user mentions "status line", "install status", "set up status", or wants to see git status in Claude Code's status bar.
   This agent handles the complete installation workflow including verification and configuration.
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -36,8 +37,16 @@ You execute the installation script and verify successful setup.
 - UserPromptSubmit hook is managed in plugin's hooks/hooks.json and uses ${CLAUDE_PLUGIN_ROOT}
 </CRITICAL_RULES>
 
+<ARGUMENTS>
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
+</ARGUMENTS>
+
 <WORKFLOW>
 ## Installation Workflow
+
+### 0. Parse Arguments
+- Parse any --context argument
+- If --context provided, apply as additional instructions to workflow
 
 ### 1. Pre-Installation Checks
 - Verify current directory is a git repository

--- a/plugins/status/agents/status-sync.md
+++ b/plugins/status/agents/status-sync.md
@@ -4,6 +4,7 @@ description: |
   MUST BE USED when user wants to refresh or sync the status line cache.
   Use PROACTIVELY when user mentions "refresh status", "sync status", "status out of date", or reports status line showing stale information.
   This agent forces a cache refresh and displays comprehensive repository status to trigger statusLine update.
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -40,8 +41,16 @@ This agent solves the "one step behind" problem by:
 - The hash is derived from the repository path
 </CRITICAL_RULES>
 
+<ARGUMENTS>
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
+</ARGUMENTS>
+
 <WORKFLOW>
 ## Sync Workflow
+
+### 0. Parse Arguments
+- Parse any --context argument
+- If --context provided, apply as additional instructions to workflow
 
 ### 1. Pre-Sync Checks
 - Verify current directory is a git repository

--- a/plugins/status/commands/install.md
+++ b/plugins/status/commands/install.md
@@ -3,7 +3,7 @@ name: fractary-status:install
 description: Install status line - delegates to fractary-status:status-install agent
 allowed-tools: Task(fractary-status:status-install)
 model: claude-haiku-4-5
-argument-hint: ''
+argument-hint: '[--context "<text>"]'
 ---
 
 Delegates to fractary-status:status-install agent for installing the custom status line in the current project.

--- a/plugins/status/commands/sync.md
+++ b/plugins/status/commands/sync.md
@@ -3,7 +3,7 @@ name: fractary-status:sync
 description: Sync status cache - delegates to fractary-status:status-sync agent
 allowed-tools: Task(fractary-status:status-sync)
 model: claude-haiku-4-5
-argument-hint: ''
+argument-hint: '[--context "<text>"]'
 ---
 
 Delegates to fractary-status:status-sync agent for refreshing the status cache and displaying current repository status.

--- a/plugins/work/README.md
+++ b/plugins/work/README.md
@@ -238,6 +238,31 @@ The work plugin provides user-facing commands for common operations:
 
 **Command Documentation:** See `commands/*.md` for detailed command documentation and examples.
 
+## Global Arguments
+
+All commands support the `--context` argument for passing additional instructions:
+
+```bash
+--context "<text>"
+```
+
+This argument is always optional and appears as the final argument. When provided, agents prepend the context as additional instructions to their workflow.
+
+**Examples:**
+
+```bash
+# Guide issue creation
+/fractary-work:issue-create "Add feature" --context "Follow team's issue template"
+
+# Focus issue refinement
+/fractary-work:issue-refine 123 --context "Emphasize performance requirements"
+
+# Customize search behavior
+/fractary-work:issue-search "auth" --context "Focus on security-related issues"
+```
+
+See [Context Argument Standard](../../docs/plugin-development/context-argument-standard.md) for full documentation.
+
 ## Session Tracking
 
 The work plugin automatically posts progress updates to issues when working on issue-linked branches.

--- a/plugins/work/agents/init.md
+++ b/plugins/work/agents/init.md
@@ -3,6 +3,7 @@ name: fractary-work:init
 description: |
   MUST BE USED when user wants to initialize or configure the work plugin for a project.
   Use PROACTIVELY when user mentions "setup work tracking", "configure issues", "connect to GitHub/Jira/Linear", or when work commands fail due to missing configuration.
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -18,11 +19,22 @@ Your role is to initialize and configure work tracking for a project, setting up
 2. ALWAYS create .fractary/plugins/work/config.json
 3. ALWAYS validate authentication before completing
 4. NEVER store tokens in config files - use environment variables
+5. With --context, prepend as additional instructions to workflow
 </CRITICAL_RULES>
 
+<ARGUMENTS>
+- `--platform <name>` - Platform: github, jira, linear (auto-detected if not provided)
+- `--token <value>` - API token (prompted if not provided)
+- `--yes` - Skip confirmation prompts
+- `--force` - Overwrite existing configuration
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
+</ARGUMENTS>
+
 <WORKFLOW>
-1. Check if already initialized (config.json exists)
-2. Detect platform from git remote URL (github.com, gitlab.com, bitbucket.org)
+1. Parse arguments (--platform, --token, --yes, --force, --context)
+2. If --context provided, apply as additional instructions to workflow
+3. Check if already initialized (config.json exists)
+4. Detect platform from git remote URL (github.com, gitlab.com, bitbucket.org)
 3. If ambiguous, ask user which platform to use
 4. Validate authentication (GITHUB_TOKEN, JIRA_TOKEN, LINEAR_API_KEY)
 5. Create configuration file with platform settings

--- a/plugins/work/agents/issue-refine.md
+++ b/plugins/work/agents/issue-refine.md
@@ -4,6 +4,7 @@ description: |
   Reviews GitHub issues and asks clarifying questions to ensure requirement clarity.
   Focuses on WHAT (requirements, goals, scope, acceptance criteria) not HOW (implementation).
   Part of the "frame phase" before architectural planning.
+color: orange
 model: claude-opus-4-5
 allowed-tools: Bash(gh issue *), AskUserQuestion(*)
 ---
@@ -25,7 +26,13 @@ This is a "frame phase" tool that bridges the gap between issue creation and arc
 6. NEVER ask technical/architectural questions (defer to spec-refine)
 7. NEVER skip the user interaction step - user must be prompted before changes
 8. NEVER generate generic questions like "Have you considered edge cases?"
+9. With --context, prepend as additional instructions to workflow
 </CRITICAL_RULES>
+
+<ARGUMENTS>
+- `<number>` - GitHub issue number to refine (required)
+- `--context "<text>"` - Optional: Additional instructions prepended to workflow
+</ARGUMENTS>
 
 <WORKFLOW>
 
@@ -33,7 +40,7 @@ This is a "frame phase" tool that bridges the gap between issue creation and arc
 
 Parse arguments:
 - `<number>` (required): GitHub issue number to refine
-- `--prompt "<focus>"` (optional): Specific area to focus refinement on
+- `--context "<text>"` (optional): Additional instructions prepended to workflow
 
 Execute:
 ```bash

--- a/plugins/work/archived/agents/issue-create.md
+++ b/plugins/work/archived/agents/issue-create.md
@@ -3,6 +3,7 @@ name: fractary-work:issue-create
 description: |
   MUST BE USED when user wants to create a new issue or work item.
   Use PROACTIVELY when user mentions "create issue", "file a bug", "add a feature request", "open ticket", or describes a problem/feature that should be tracked.
+color: orange
 model: claude-haiku-4-5
 ---
 
@@ -16,14 +17,14 @@ Your role is to create new issues in work tracking systems (GitHub Issues, Jira,
 <CRITICAL_RULES>
 1. ALWAYS validate title is provided
 2. ALWAYS convert --type to appropriate label format
-3. ALWAYS support --prompt for AI-generated descriptions from conversation context
+3. ALWAYS support --context for additional instructions prepended to workflow
 4. ALWAYS support --branch-create and --spec-create flags for workflow automation
 5. NEVER execute gh/jira/linear CLI commands directly - use handler skills
 </CRITICAL_RULES>
 
 <WORKFLOW>
 1. Parse parameters: title, description/body, type, labels, milestone, assignee
-2. If --prompt provided without body, generate description from conversation context
+2. If --context provided, prepend as additional instructions to workflow
 3. Convert --type to label format (e.g., "type: feature")
 4. Load configuration to determine active platform
 5. Invoke handler-work-tracker-{platform} skill with create-issue operation

--- a/plugins/work/archived/agents/issue-fetch.md
+++ b/plugins/work/archived/agents/issue-fetch.md
@@ -3,6 +3,7 @@ name: fractary-work:issue-fetch
 description: |
   MUST BE USED when user wants to view or fetch details of an issue.
   Use PROACTIVELY when user mentions "show issue", "get issue details", "what's in issue #X", or wants to see issue information.
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/work/archived/agents/issue-list.md
+++ b/plugins/work/archived/agents/issue-list.md
@@ -3,6 +3,7 @@ name: fractary-work:issue-list
 description: |
   MUST BE USED when user wants to list or browse issues.
   Use PROACTIVELY when user mentions "list issues", "show open issues", "what issues are there", or wants to see available work items.
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/work/archived/agents/issue-search.md
+++ b/plugins/work/archived/agents/issue-search.md
@@ -3,6 +3,7 @@ name: fractary-work:issue-search
 description: |
   MUST BE USED when user wants to search for issues by keyword or criteria.
   Use PROACTIVELY when user mentions "search issues", "find issues about X", "look for issues", or needs to locate specific work items.
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/work/archived/agents/issue-update.md
+++ b/plugins/work/archived/agents/issue-update.md
@@ -3,6 +3,7 @@ name: fractary-work:issue-update
 description: |
   MUST BE USED when user wants to update an issue's title or description.
   Use PROACTIVELY when user mentions "update issue", "change issue title", "edit issue description", or wants to modify issue content.
+color: orange
 model: claude-haiku-4-5
 ---
 

--- a/plugins/work/commands/init.md
+++ b/plugins/work/commands/init.md
@@ -3,7 +3,7 @@ name: fractary-work:init
 description: Initialize work plugin - delegates to fractary-work:init agent
 allowed-tools: Task(fractary-work:init)
 model: claude-haiku-4-5
-argument-hint: '[--platform github|jira|linear] [--token <value>] [--yes] [--force]'
+argument-hint: '[--platform github|jira|linear] [--token <value>] [--yes] [--force] [--context "<text>"]'
 ---
 
 Delegates to fractary-work:init agent for initializing work tracking configuration.

--- a/plugins/work/commands/issue-create.md
+++ b/plugins/work/commands/issue-create.md
@@ -3,7 +3,7 @@ name: fractary-work:issue-create
 allowed-tools: Bash(gh issue create:*), Bash(gh repo view:*), Bash(gh issue list:*)
 description: Create new issue
 model: claude-haiku-4-5
-argument-hint: '[--title "<title>"] [--body "<text>"] [--label <label>] [--assignee <user>]'
+argument-hint: '[--title "<title>"] [--body "<text>"] [--label <label>] [--assignee <user>] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/work/commands/issue-fetch.md
+++ b/plugins/work/commands/issue-fetch.md
@@ -3,7 +3,7 @@ name: fractary-work:issue-fetch
 allowed-tools: Bash(gh issue view:*)
 description: Fetch issue details
 model: claude-haiku-4-5
-argument-hint: '<number>'
+argument-hint: '<number> [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/work/commands/issue-list.md
+++ b/plugins/work/commands/issue-list.md
@@ -3,7 +3,7 @@ name: fractary-work:issue-list
 allowed-tools: Bash(gh issue list:*)
 description: List issues
 model: claude-haiku-4-5
-argument-hint: '[--state <open|closed|all>] [--label <label>] [--assignee <user>] [--limit <n>]'
+argument-hint: '[--state <open|closed|all>] [--label <label>] [--assignee <user>] [--limit <n>] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/work/commands/issue-refine.md
+++ b/plugins/work/commands/issue-refine.md
@@ -3,7 +3,7 @@ name: fractary-work:issue-refine
 description: Refine issue requirements through clarifying questions
 allowed-tools: Task(fractary-work:issue-refine-agent)
 model: claude-opus-4-5
-argument-hint: '<number> [--prompt "<focus>"]'
+argument-hint: '<number> [--context "<text>"]'
 ---
 
 Delegates to fractary-work:issue-refine-agent for reviewing and clarifying issue requirements.

--- a/plugins/work/commands/issue-search.md
+++ b/plugins/work/commands/issue-search.md
@@ -3,7 +3,7 @@ name: fractary-work:issue-search
 allowed-tools: Bash(gh search issues:*), Bash(gh repo view:*)
 description: Search issues
 model: claude-haiku-4-5
-argument-hint: '<query> [--state <state>] [--limit <n>]'
+argument-hint: '<query> [--state <state>] [--limit <n>] [--context "<text>"]'
 ---
 
 ## Context

--- a/plugins/work/commands/issue-update.md
+++ b/plugins/work/commands/issue-update.md
@@ -3,7 +3,7 @@ name: fractary-work:issue-update
 allowed-tools: Bash(gh issue edit:*)
 description: Update issue
 model: claude-haiku-4-5
-argument-hint: '<number> [--title "<title>"] [--body "<text>"]'
+argument-hint: '<number> [--title "<title>"] [--body "<text>"] [--context "<text>"]'
 ---
 
 ## Context

--- a/scripts/validate-context-support.sh
+++ b/scripts/validate-context-support.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# validate-context-support.sh
+# Validates that all plugin commands and agents have proper --context support
+#
+# Usage: ./scripts/validate-context-support.sh
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGINS_DIR="${SCRIPT_DIR}/../plugins"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Counters
+COMMANDS_TOTAL=0
+COMMANDS_PASS=0
+COMMANDS_FAIL=0
+AGENTS_TOTAL=0
+AGENTS_PASS=0
+AGENTS_FAIL=0
+DEPRECATED_FOUND=0
+
+echo "============================================"
+echo "  Context Argument Support Validation"
+echo "============================================"
+echo ""
+
+# Check commands
+echo "Checking commands for --context in argument-hint..."
+echo "--------------------------------------------"
+
+for plugin_dir in "${PLUGINS_DIR}"/*/; do
+    plugin_name=$(basename "$plugin_dir")
+    commands_dir="${plugin_dir}commands"
+
+    if [[ -d "$commands_dir" ]]; then
+        for cmd_file in "${commands_dir}"/*.md; do
+            if [[ -f "$cmd_file" ]]; then
+                COMMANDS_TOTAL=$((COMMANDS_TOTAL + 1))
+                cmd_name=$(basename "$cmd_file" .md)
+
+                # Check if argument-hint contains --context
+                if grep -q 'argument-hint:.*--context' "$cmd_file"; then
+                    COMMANDS_PASS=$((COMMANDS_PASS + 1))
+                    echo -e "  ${GREEN}✓${NC} ${plugin_name}:${cmd_name}"
+                else
+                    COMMANDS_FAIL=$((COMMANDS_FAIL + 1))
+                    echo -e "  ${RED}✗${NC} ${plugin_name}:${cmd_name} - missing --context in argument-hint"
+                fi
+            fi
+        done
+    fi
+done
+
+echo ""
+
+# Check non-archived agents
+echo "Checking agents for --context in ARGUMENTS section..."
+echo "--------------------------------------------"
+
+for plugin_dir in "${PLUGINS_DIR}"/*/; do
+    plugin_name=$(basename "$plugin_dir")
+    agents_dir="${plugin_dir}agents"
+
+    if [[ -d "$agents_dir" ]]; then
+        for agent_file in "${agents_dir}"/*.md; do
+            if [[ -f "$agent_file" ]]; then
+                AGENTS_TOTAL=$((AGENTS_TOTAL + 1))
+                agent_name=$(basename "$agent_file" .md)
+
+                # Check if file contains --context in ARGUMENTS section
+                if grep -q '\-\-context.*Optional.*Additional instructions' "$agent_file"; then
+                    AGENTS_PASS=$((AGENTS_PASS + 1))
+                    echo -e "  ${GREEN}✓${NC} ${plugin_name}:${agent_name}"
+                else
+                    AGENTS_FAIL=$((AGENTS_FAIL + 1))
+                    echo -e "  ${RED}✗${NC} ${plugin_name}:${agent_name} - missing --context in ARGUMENTS"
+                fi
+            fi
+        done
+    fi
+done
+
+echo ""
+
+# Check for deprecated --prompt usage in non-archived files
+echo "Checking for deprecated --prompt usage..."
+echo "--------------------------------------------"
+
+for plugin_dir in "${PLUGINS_DIR}"/*/; do
+    plugin_name=$(basename "$plugin_dir")
+
+    # Check commands (exclude archived)
+    commands_dir="${plugin_dir}commands"
+    if [[ -d "$commands_dir" ]]; then
+        for cmd_file in "${commands_dir}"/*.md; do
+            if [[ -f "$cmd_file" ]]; then
+                # Check for --prompt in argument-hint (not in comments or examples)
+                if grep -q 'argument-hint:.*--prompt' "$cmd_file"; then
+                    DEPRECATED_FOUND=$((DEPRECATED_FOUND + 1))
+                    echo -e "  ${YELLOW}!${NC} ${plugin_name}/commands/$(basename "$cmd_file") - still uses --prompt"
+                fi
+            fi
+        done
+    fi
+
+    # Check agents (exclude archived)
+    agents_dir="${plugin_dir}agents"
+    if [[ -d "$agents_dir" ]]; then
+        for agent_file in "${agents_dir}"/*.md; do
+            if [[ -f "$agent_file" ]]; then
+                # Check for --prompt in ARGUMENTS section
+                if grep -q '\-\-prompt.*Additional\|prompt.*Optional.*Additional' "$agent_file"; then
+                    DEPRECATED_FOUND=$((DEPRECATED_FOUND + 1))
+                    echo -e "  ${YELLOW}!${NC} ${plugin_name}/agents/$(basename "$agent_file") - still uses --prompt"
+                fi
+            fi
+        done
+    fi
+done
+
+if [[ $DEPRECATED_FOUND -eq 0 ]]; then
+    echo -e "  ${GREEN}✓${NC} No deprecated --prompt references found"
+fi
+
+echo ""
+echo "============================================"
+echo "  Summary"
+echo "============================================"
+echo ""
+echo "Commands:"
+echo -e "  Total:  $COMMANDS_TOTAL"
+echo -e "  Pass:   ${GREEN}$COMMANDS_PASS${NC}"
+echo -e "  Fail:   ${RED}$COMMANDS_FAIL${NC}"
+echo ""
+echo "Agents:"
+echo -e "  Total:  $AGENTS_TOTAL"
+echo -e "  Pass:   ${GREEN}$AGENTS_PASS${NC}"
+echo -e "  Fail:   ${RED}$AGENTS_FAIL${NC}"
+echo ""
+echo "Deprecated --prompt:"
+echo -e "  Found:  ${YELLOW}$DEPRECATED_FOUND${NC}"
+echo ""
+
+# Exit with error if any failures
+if [[ $COMMANDS_FAIL -gt 0 ]] || [[ $AGENTS_FAIL -gt 0 ]] || [[ $DEPRECATED_FOUND -gt 0 ]]; then
+    echo -e "${RED}Validation FAILED${NC}"
+    exit 1
+else
+    echo -e "${GREEN}Validation PASSED${NC}"
+    exit 0
+fi

--- a/specs/SPEC-20251229-context-argument-support.md
+++ b/specs/SPEC-20251229-context-argument-support.md
@@ -1,0 +1,734 @@
+---
+spec_id: SPEC-20251229-context-argument-support
+title: Universal --context Argument Support for Fractary Core Plugins
+type: feature
+status: draft
+created: 2025-12-29
+author: claude-opus-4-5
+validated: false
+source: conversation
+related_docs:
+  - plugins/spec/commands/create.md
+  - plugins/spec/commands/refine.md
+  - plugins/docs/commands/write.md
+  - plugins/work/commands/issue-refine.md
+changelog: []
+---
+
+# Feature Specification: Universal --context Argument Support
+
+**Type**: Feature - Systematic Enhancement
+**Status**: Draft
+**Created**: 2025-12-29
+
+## 1. Executive Summary
+
+This specification details the systematic addition of a `--context` argument to all 41 Fractary Core plugin commands and updates to 29 agents to handle contextual instructions. This enhancement provides users with a consistent, universal mechanism to pass additional contextual instructions to any command, enabling more flexible and precise control over agent behavior.
+
+### 1.1 Scope
+
+This document covers:
+- Migration of existing `--prompt` arguments to `--context` for consistency
+- Addition of `--context` to all 41 commands across 7 plugins
+- Updates to 29 agents to parse and apply context appropriately
+- Standardized patterns for context handling
+- Backward compatibility considerations
+
+### 1.2 Design Goals
+
+1. **Universal Availability** - Every command supports `--context`
+2. **Consistent Naming** - Replace inconsistent `--prompt` with standardized `--context`
+3. **Non-Breaking** - Existing workflows continue to function
+4. **Minimal Overhead** - Context is optional, no impact when unused
+5. **Agent Awareness** - Agents understand and apply context appropriately
+
+### 1.3 Key Metrics
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Commands with context support | 5 | 41 |
+| Agents with context handling | 4 | 29 |
+| Consistent argument naming | No (`--prompt` vs `--context`) | Yes (`--context`) |
+| Universal availability | 12% of commands | 100% of commands |
+
+## 2. Background & Motivation
+
+### 2.1 Current State
+
+Currently, only a small subset of commands support passing additional instructions:
+
+| Plugin | Command | Current Argument |
+|--------|---------|------------------|
+| spec | create | `--prompt` |
+| spec | refine | `--prompt` |
+| docs | write | `--prompt` |
+| work | issue-refine | `--prompt` |
+
+**Issues with Current State:**
+
+1. **Inconsistent Availability** - Most commands lack context support
+2. **Inconsistent Naming** - Some use `--prompt`, implying generation rather than guidance
+3. **Missing Capability** - Users cannot guide agent behavior for 36 commands
+4. **Discoverability** - No standard pattern for users to expect
+
+### 2.2 Use Cases Enabled by Universal --context
+
+**Use Case 1: Focused Operations**
+```bash
+# Focus documentation audit on security concerns
+/fractary-docs:audit --context "Focus on security-related documentation gaps"
+
+# Commit with specific style guidance
+/fractary-repo:commit --context "Use conventional commit format with scope"
+```
+
+**Use Case 2: Output Customization**
+```bash
+# Get verbose log analysis
+/fractary-logs:analyze errors --context "Include full stack traces and timestamps"
+
+# Concise issue list
+/fractary-work:issue-list --context "Show only critical bugs, one line per issue"
+```
+
+**Use Case 3: Behavioral Guidance**
+```bash
+# Conservative file operations
+/fractary-file:switch-handler s3 --context "Verify current data is backed up before switching"
+
+# Strict validation
+/fractary-spec:validate --context "Apply strict validation, fail on any warnings"
+```
+
+**Use Case 4: Domain-Specific Context**
+```bash
+# Healthcare compliance context
+/fractary-docs:write api --context "This API handles PHI data, ensure HIPAA compliance is documented"
+
+# Financial context
+/fractary-logs:audit --context "Flag any operations involving financial transactions"
+```
+
+## 3. Architecture
+
+### 3.1 Pattern Overview
+
+The `--context` argument follows a simple flow:
+
+```
+User Command with --context
+         |
+         v
+    Command File (argument-hint includes --context)
+         |
+         v
+    Task Tool Invocation (passes $ARGUMENTS including --context)
+         |
+         v
+    Agent (parses --context, applies to behavior)
+         |
+         v
+    Execution (context influences decisions/output)
+```
+
+### 3.2 Command File Changes
+
+Every command file requires:
+
+1. **argument-hint update** - Add `[--context "<instructions>"]` to argument-hint
+2. **No logic changes** - Commands already pass `$ARGUMENTS` to agents
+
+**Before:**
+```yaml
+---
+name: fractary-logs:analyze
+argument-hint: '<type> [--issue <number>] [--since <date>] [--until <date>] [--verbose]'
+---
+```
+
+**After:**
+```yaml
+---
+name: fractary-logs:analyze
+argument-hint: '<type> [--issue <number>] [--since <date>] [--until <date>] [--verbose] [--context "<instructions>"]'
+---
+```
+
+### 3.3 Agent File Changes
+
+Each agent requires updates to:
+
+1. **ARGUMENTS section** - Document `--context` parameter
+2. **WORKFLOW section** - Include context parsing in step 1
+3. **CONTEXT_HANDLING section** (new) - Define how context is applied
+
+**New Section Pattern:**
+```markdown
+<CONTEXT_HANDLING>
+The `--context` argument provides additional instructions that influence agent behavior.
+
+**How context is applied:**
+- [Specific to agent: focus areas, output formatting, validation strictness, etc.]
+
+**Examples:**
+- `--context "Focus on security issues"` - Prioritizes security-related findings
+- `--context "Be verbose"` - Provides detailed output
+- `--context "Skip X"` - Excludes specific items
+
+**Context does NOT:**
+- Override explicit arguments (--verbose always means verbose)
+- Change core functionality (analyze still analyzes)
+- Bypass safety checks or validations
+</CONTEXT_HANDLING>
+```
+
+### 3.4 Argument Precedence
+
+When `--context` conflicts with explicit arguments:
+
+1. **Explicit arguments win** - `--verbose` always means verbose, even if context says "be brief"
+2. **Context refines behavior** - Context guides HOW explicit arguments are interpreted
+3. **Context fills gaps** - Context provides guidance where no explicit argument exists
+
+## 4. Migration from --prompt to --context
+
+### 4.1 Rationale for Renaming
+
+| Aspect | `--prompt` | `--context` |
+|--------|-----------|-------------|
+| Implication | "Generate something" | "Here's additional guidance" |
+| Scope | Generation-focused | Universal applicability |
+| Clarity | Ambiguous (prompt for what?) | Clear (contextual instructions) |
+| Industry Standard | Less common | More common (LLM tooling) |
+
+### 4.2 Migration Strategy
+
+**Phase 1: Add --context everywhere (non-breaking)**
+- All commands gain `--context` support
+- Agents updated to parse `--context`
+
+**Phase 2: Deprecate --prompt (soft warning)**
+- Commands with `--prompt` also accept `--context`
+- Using `--prompt` logs deprecation notice
+- Documentation updated to prefer `--context`
+
+**Phase 3: Remove --prompt (future)**
+- `--prompt` removed from argument-hints
+- Agents no longer parse `--prompt`
+- Only if breaking change is acceptable
+
+### 4.3 Backward Compatibility
+
+For commands currently using `--prompt`:
+
+```markdown
+<ARGUMENTS>
+- `--context "<instructions>"` - Additional contextual instructions (preferred)
+- `--prompt "<instructions>"` - Alias for --context (deprecated, use --context)
+</ARGUMENTS>
+
+<WORKFLOW>
+## Step 1: Parse Arguments
+...
+- `--context` or `--prompt`: Additional instructions (--context takes precedence)
+...
+</WORKFLOW>
+```
+
+## 5. Complete Command Inventory
+
+### 5.1 docs Plugin (5 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| audit | none | Yes | docs-audit.md |
+| check-consistency | none | Yes | docs-check-consistency.md |
+| list | none | Yes | docs-list.md |
+| validate | none | Yes | docs-validate.md |
+| write | `--prompt` | Migrate | docs-write.md |
+
+### 5.2 file Plugin (4 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| init | none | Yes | file-init.md |
+| show-config | none | Yes | file-show-config.md |
+| switch-handler | none | Yes | file-switch-handler.md |
+| test-connection | none | Yes | file-test-connection.md |
+
+### 5.3 logs Plugin (10 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| analyze | none | Yes | logs-analyze.md |
+| archive | none | Yes | logs-archive.md |
+| audit | none | Yes | logs-audit.md |
+| capture | none | Yes | logs-capture.md |
+| cleanup | none | Yes | logs-cleanup.md |
+| init | none | Yes | logs-init.md |
+| log | none | Yes | logs-log.md |
+| read | none | Yes | logs-read.md |
+| search | none | Yes | logs-search.md |
+| stop | none | Yes | logs-stop.md |
+
+### 5.4 repo Plugin (8 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| commit | none | Yes | N/A (direct) |
+| commit-push | none | Yes | N/A (direct) |
+| commit-push-pr | none | Yes | N/A (direct) |
+| init | none | Yes | init.md |
+| pr-create | none | Yes | N/A (direct) |
+| pr-merge | none | Yes | N/A (direct) |
+| pr-review | none | Yes | N/A (direct) |
+| pull | none | Yes | N/A (direct) |
+
+### 5.5 spec Plugin (5 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| archive | none | Yes | spec-archive.md |
+| create | `--prompt` | Migrate | spec-create.md |
+| init | none | Yes | spec-init.md |
+| refine | `--prompt` | Migrate | spec-refine.md |
+| validate | none | Yes | spec-validate.md |
+
+### 5.6 status Plugin (2 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| install | none | Yes | status-install.md |
+| sync | none | Yes | status-sync.md |
+
+### 5.7 work Plugin (7 commands)
+
+| Command | Current Args | Add --context | Agent Update |
+|---------|-------------|---------------|--------------|
+| init | none | Yes | init.md |
+| issue-create | none | Yes | N/A (direct) |
+| issue-fetch | none | Yes | N/A (direct) |
+| issue-list | none | Yes | N/A (direct) |
+| issue-refine | `--prompt` | Migrate | issue-refine.md |
+| issue-search | none | Yes | N/A (direct) |
+| issue-update | none | Yes | N/A (direct) |
+
+### 5.8 Summary Totals
+
+| Category | Count |
+|----------|-------|
+| Total Commands | 41 |
+| Commands needing --context added | 37 |
+| Commands with --prompt to migrate | 4 |
+| Agents needing updates | 29 |
+| Direct commands (no agent) | 12 |
+
+## 6. Agent Update Patterns
+
+### 6.1 Standard Agent Update Template
+
+For agents that delegate to skills or perform multi-step workflows:
+
+```markdown
+<ARGUMENTS>
+- `[existing args...]`
+- `--context "<instructions>"` - Optional: Additional contextual instructions
+</ARGUMENTS>
+
+<WORKFLOW>
+## Step 1: Parse Arguments
+- Parse all explicit arguments
+- Extract `--context` if provided
+- Apply context to workflow decisions where appropriate
+...
+</WORKFLOW>
+
+<CONTEXT_HANDLING>
+The `--context` argument provides additional instructions that influence agent behavior.
+
+**How context is applied:**
+- Influences [specific decision points for this agent]
+- Adjusts [output format, verbosity, focus areas]
+- Guides [prioritization, filtering, selection]
+
+**Context does NOT:**
+- Override explicit arguments
+- Change core operation semantics
+- Bypass validation or safety checks
+</CONTEXT_HANDLING>
+```
+
+### 6.2 Direct Command Pattern
+
+For commands without dedicated agents (e.g., issue-create, pr-create):
+
+```markdown
+---
+name: fractary-work:issue-create
+argument-hint: '[--title "<title>"] [--body "<text>"] [--label <label>] [--assignee <user>] [--context "<instructions>"]'
+---
+
+## Context Handling
+
+If `--context` is provided, use it to guide:
+- Issue title/body generation when not explicitly provided
+- Label selection based on context hints
+- Description formatting and detail level
+
+Parse arguments:
+- --title: Issue title (or generate from conversation context)
+- --body: Issue description (or generate from conversation context)
+- --context: Additional instructions for generation/formatting
+...
+```
+
+### 6.3 Context Application Examples by Agent Type
+
+**Audit/Analysis Agents:**
+```markdown
+<CONTEXT_HANDLING>
+**How context is applied:**
+- Focus areas: `--context "Focus on security"` prioritizes security findings
+- Severity filtering: `--context "Only critical issues"` filters output
+- Verbosity: `--context "Include recommendations"` adds remediation guidance
+</CONTEXT_HANDLING>
+```
+
+**Write/Create Agents:**
+```markdown
+<CONTEXT_HANDLING>
+**How context is applied:**
+- Content focus: `--context "For technical audience"` adjusts language
+- Format preferences: `--context "Use bullet points"` influences structure
+- Domain context: `--context "Healthcare domain"` adds relevant terminology
+</CONTEXT_HANDLING>
+```
+
+**Init/Setup Agents:**
+```markdown
+<CONTEXT_HANDLING>
+**How context is applied:**
+- Configuration preferences: `--context "Minimal setup"` reduces defaults
+- Environment hints: `--context "Production environment"` adjusts settings
+- Safety level: `--context "Verify before changes"` adds confirmation steps
+</CONTEXT_HANDLING>
+```
+
+## 7. Implementation Plan
+
+### 7.1 Phase 1: Command File Updates (41 files)
+
+Update `argument-hint` in all command files:
+
+**docs plugin (5 files):**
+- [ ] `/plugins/docs/commands/audit.md`
+- [ ] `/plugins/docs/commands/check-consistency.md`
+- [ ] `/plugins/docs/commands/list.md`
+- [ ] `/plugins/docs/commands/validate.md`
+- [ ] `/plugins/docs/commands/write.md` (migrate --prompt)
+
+**file plugin (4 files):**
+- [ ] `/plugins/file/commands/init.md`
+- [ ] `/plugins/file/commands/show-config.md`
+- [ ] `/plugins/file/commands/switch-handler.md`
+- [ ] `/plugins/file/commands/test-connection.md`
+
+**logs plugin (10 files):**
+- [ ] `/plugins/logs/commands/analyze.md`
+- [ ] `/plugins/logs/commands/archive.md`
+- [ ] `/plugins/logs/commands/audit.md`
+- [ ] `/plugins/logs/commands/capture.md`
+- [ ] `/plugins/logs/commands/cleanup.md`
+- [ ] `/plugins/logs/commands/init.md`
+- [ ] `/plugins/logs/commands/log.md`
+- [ ] `/plugins/logs/commands/read.md`
+- [ ] `/plugins/logs/commands/search.md`
+- [ ] `/plugins/logs/commands/stop.md`
+
+**repo plugin (8 files):**
+- [ ] `/plugins/repo/commands/commit.md`
+- [ ] `/plugins/repo/commands/commit-push.md`
+- [ ] `/plugins/repo/commands/commit-push-pr.md`
+- [ ] `/plugins/repo/commands/init.md`
+- [ ] `/plugins/repo/commands/pr-create.md`
+- [ ] `/plugins/repo/commands/pr-merge.md`
+- [ ] `/plugins/repo/commands/pr-review.md`
+- [ ] `/plugins/repo/commands/pull.md`
+
+**spec plugin (5 files):**
+- [ ] `/plugins/spec/commands/archive.md`
+- [ ] `/plugins/spec/commands/create.md` (migrate --prompt)
+- [ ] `/plugins/spec/commands/init.md`
+- [ ] `/plugins/spec/commands/refine.md` (migrate --prompt)
+- [ ] `/plugins/spec/commands/validate.md`
+
+**status plugin (2 files):**
+- [ ] `/plugins/status/commands/install.md`
+- [ ] `/plugins/status/commands/sync.md`
+
+**work plugin (7 files):**
+- [ ] `/plugins/work/commands/init.md`
+- [ ] `/plugins/work/commands/issue-create.md`
+- [ ] `/plugins/work/commands/issue-fetch.md`
+- [ ] `/plugins/work/commands/issue-list.md`
+- [ ] `/plugins/work/commands/issue-refine.md` (migrate --prompt)
+- [ ] `/plugins/work/commands/issue-search.md`
+- [ ] `/plugins/work/commands/issue-update.md`
+
+### 7.2 Phase 2: Agent File Updates (29 files)
+
+Update agents with ARGUMENTS, WORKFLOW, and CONTEXT_HANDLING sections:
+
+**docs plugin (5 agents):**
+- [ ] `/plugins/docs/agents/docs-audit.md`
+- [ ] `/plugins/docs/agents/docs-check-consistency.md`
+- [ ] `/plugins/docs/agents/docs-list.md`
+- [ ] `/plugins/docs/agents/docs-validate.md`
+- [ ] `/plugins/docs/agents/docs-write.md`
+
+**file plugin (4 agents):**
+- [ ] `/plugins/file/agents/file-init.md`
+- [ ] `/plugins/file/agents/file-show-config.md`
+- [ ] `/plugins/file/agents/file-switch-handler.md`
+- [ ] `/plugins/file/agents/file-test-connection.md`
+
+**logs plugin (10 agents):**
+- [ ] `/plugins/logs/agents/logs-analyze.md`
+- [ ] `/plugins/logs/agents/logs-archive.md`
+- [ ] `/plugins/logs/agents/logs-audit.md`
+- [ ] `/plugins/logs/agents/logs-capture.md`
+- [ ] `/plugins/logs/agents/logs-cleanup.md`
+- [ ] `/plugins/logs/agents/logs-init.md`
+- [ ] `/plugins/logs/agents/logs-log.md`
+- [ ] `/plugins/logs/agents/logs-read.md`
+- [ ] `/plugins/logs/agents/logs-search.md`
+- [ ] `/plugins/logs/agents/logs-stop.md`
+
+**repo plugin (1 agent):**
+- [ ] `/plugins/repo/agents/init.md`
+
+**spec plugin (5 agents):**
+- [ ] `/plugins/spec/agents/spec-archive.md`
+- [ ] `/plugins/spec/agents/spec-create.md`
+- [ ] `/plugins/spec/agents/spec-init.md`
+- [ ] `/plugins/spec/agents/spec-refine.md`
+- [ ] `/plugins/spec/agents/spec-validate.md`
+
+**status plugin (2 agents):**
+- [ ] `/plugins/status/agents/status-install.md`
+- [ ] `/plugins/status/agents/status-sync.md`
+
+**work plugin (2 agents):**
+- [ ] `/plugins/work/agents/init.md`
+- [ ] `/plugins/work/agents/issue-refine.md`
+
+### 7.3 Phase 3: Plugin Manifest Updates (7 files)
+
+Update version numbers in plugin manifests:
+
+- [ ] `/plugins/docs/.claude-plugin/plugin.json`
+- [ ] `/plugins/file/.claude-plugin/plugin.json`
+- [ ] `/plugins/logs/.claude-plugin/plugin.json`
+- [ ] `/plugins/repo/.claude-plugin/plugin.json`
+- [ ] `/plugins/spec/.claude-plugin/plugin.json`
+- [ ] `/plugins/status/.claude-plugin/plugin.json`
+- [ ] `/plugins/work/.claude-plugin/plugin.json`
+
+### 7.4 Phase 4: Testing
+
+**Unit Testing (per command):**
+- [ ] Verify --context is accepted without error
+- [ ] Verify --context is passed to agent
+- [ ] Verify context influences behavior appropriately
+- [ ] Verify explicit arguments override context
+
+**Integration Testing (per plugin):**
+- [ ] Test commands with --context across plugin
+- [ ] Verify no regression in existing functionality
+- [ ] Test edge cases (empty context, very long context)
+
+**Migration Testing (4 commands):**
+- [ ] Verify --prompt still works (backward compatibility)
+- [ ] Verify --context takes precedence over --prompt
+- [ ] Verify deprecation notice is shown for --prompt
+
+### 7.5 Phase 5: Documentation
+
+- [ ] Update plugin READMEs with --context examples
+- [ ] Add "Context Argument" section to developer guide
+- [ ] Update command reference documentation
+- [ ] Create migration guide for --prompt users
+
+## 8. File Changes Summary
+
+### 8.1 Files Modified
+
+| Category | Count | Files |
+|----------|-------|-------|
+| Command files | 41 | `/plugins/*/commands/*.md` |
+| Agent files | 29 | `/plugins/*/agents/*.md` |
+| Plugin manifests | 7 | `/plugins/*/.claude-plugin/plugin.json` |
+| **Total** | **77** | |
+
+### 8.2 Estimated Line Changes
+
+| Change Type | Estimate |
+|-------------|----------|
+| Command argument-hint additions | ~41 lines (1 per file) |
+| Agent ARGUMENTS updates | ~58 lines (2 per file) |
+| Agent WORKFLOW updates | ~87 lines (3 per file) |
+| Agent CONTEXT_HANDLING sections | ~435 lines (15 per file) |
+| **Total New/Modified Lines** | **~620 lines** |
+
+## 9. Acceptance Criteria
+
+### 9.1 Functional Requirements
+
+- [ ] All 41 commands accept `--context` argument
+- [ ] All 29 agents parse and apply `--context`
+- [ ] Context influences agent behavior appropriately
+- [ ] Explicit arguments override context suggestions
+- [ ] Commands with `--prompt` also accept `--context`
+- [ ] `--prompt` shows deprecation notice
+
+### 9.2 Non-Functional Requirements
+
+- [ ] No performance regression (context parsing is lightweight)
+- [ ] No breaking changes to existing workflows
+- [ ] Consistent documentation pattern across all agents
+- [ ] All plugin versions incremented appropriately
+
+### 9.3 Quality Criteria
+
+- [ ] 100% of commands have --context in argument-hint
+- [ ] 100% of agents have CONTEXT_HANDLING section
+- [ ] All tests pass with and without --context
+- [ ] Documentation complete for all commands
+
+## 10. Risks & Mitigations
+
+### Risk 1: Context Misinterpretation
+**Impact**: Medium - Agent misunderstands context instructions
+**Mitigation**: Clear CONTEXT_HANDLING documentation, explicit examples
+**Fallback**: Users can omit context, explicit arguments still work
+
+### Risk 2: Breaking Existing Workflows
+**Impact**: High - Users relying on --prompt experience issues
+**Mitigation**: Backward compatibility with --prompt as alias
+**Fallback**: --prompt continues to work, migration is optional
+
+### Risk 3: Inconsistent Implementation
+**Impact**: Medium - Different agents handle context differently
+**Mitigation**: Standard templates, code review checklist
+**Fallback**: Iterative refinement based on feedback
+
+### Risk 4: Scope Creep
+**Impact**: Low - Adding features beyond context support
+**Mitigation**: Strict scope definition in this spec
+**Fallback**: New features go in separate specs
+
+### Risk 5: Testing Gaps
+**Impact**: Medium - Some commands not properly tested
+**Mitigation**: Testing checklist per command, automation where possible
+**Fallback**: Manual testing before release
+
+## 11. Future Enhancements
+
+**Out of Scope for This Spec:**
+- Context history/memory across commands
+- Context templates (predefined context sets)
+- Context validation (semantic checking)
+- Context suggestions (auto-complete)
+- Context inheritance (parent command context)
+
+**Potential Future Features:**
+- `--context-file <path>` - Load context from file
+- `--context-preset <name>` - Use predefined context template
+- Context profiles per project/workspace
+- AI-suggested context based on operation
+
+## 12. Example Usage
+
+### 12.1 Before and After
+
+**Before (limited context support):**
+```bash
+# Only some commands accept guidance
+/fractary-spec:create --prompt "Focus on API design"
+/fractary-logs:analyze errors  # No way to guide analysis
+
+# Inconsistent naming
+/fractary-docs:write api --prompt "..."
+/fractary-work:issue-refine 123 --prompt "..."
+```
+
+**After (universal context support):**
+```bash
+# All commands accept --context
+/fractary-spec:create --context "Focus on API design"
+/fractary-logs:analyze errors --context "Include security-related errors only"
+/fractary-docs:audit --context "Check for outdated API references"
+/fractary-repo:commit --context "Use conventional commit format"
+/fractary-file:init --context "Configure for production environment"
+
+# Consistent naming across all plugins
+/fractary-docs:write api --context "..."
+/fractary-work:issue-refine 123 --context "..."
+```
+
+### 12.2 Real-World Scenarios
+
+**Scenario 1: Security-Focused Audit**
+```bash
+# Audit documentation with security focus
+/fractary-docs:audit --context "Focus on security documentation: authentication, authorization, data handling, and compliance"
+
+# Output prioritizes security-related gaps
+```
+
+**Scenario 2: Verbose Log Analysis**
+```bash
+# Analyze errors with full details
+/fractary-logs:analyze errors --since 2025-12-28 --context "Include full stack traces, group by error type, show frequency"
+
+# Output includes detailed breakdown
+```
+
+**Scenario 3: Domain-Specific Specification**
+```bash
+# Create spec for healthcare application
+/fractary-spec:create --work-id 456 --context "This is a healthcare application handling PHI. Ensure HIPAA compliance requirements are addressed in architecture"
+
+# Generated spec includes compliance considerations
+```
+
+**Scenario 4: Conservative Operations**
+```bash
+# Cautious file handler switch
+/fractary-file:switch-handler s3 --context "Verify all local files are synced before switching. Show diff of what will change."
+
+# Agent adds verification steps
+```
+
+## 13. Related Work
+
+**Similar Patterns in Other Tools:**
+- GitHub CLI `--body` for additional context
+- kubectl `--dry-run` for preview mode (context: "preview only")
+- terraform `-var` for runtime configuration
+
+**Internal Related Specs:**
+- SPEC-20251217202523-plugin-v3-architecture (agent structure)
+- SPEC-20251228-issue-refine-command (--prompt usage example)
+
+## 14. Notes
+
+- All commands should document context in argument-hint for discoverability
+- Context should never override explicit arguments (user intent is clear)
+- Empty context (`--context ""`) should be treated as no context
+- Very long context should be accepted (no artificial limits)
+- Context is passed as-is to agents, no preprocessing
+
+---
+
+*Specification generated from conversation context on 2025-12-29*


### PR DESCRIPTION
## Summary

Implement universal `--context` argument support across all 41 plugin commands and 29 agents, enabling users to pass additional contextual instructions to any command for flexible customization.

## Changes

### Code Updates
- **41 commands**: Added `[--context "<text>"]` as final optional argument in all command files
- **29 agents**: Added `--context` to ARGUMENTS section with proper WORKFLOW handling
- **Migration**: Renamed `--prompt` to `--context` in 4 commands and 5 agents for consistency

### Documentation
- Created `docs/plugin-development/context-argument-standard.md` - Standard template for future development
- Updated all 7 plugin READMEs with "Global Arguments" section with examples
- Created `scripts/validate-context-support.sh` - Validation script for CI/CD

### Validation
- ✅ All 41 commands pass validation
- ✅ All 29 agents pass validation
- ✅ No deprecated `--prompt` references remain
- ✅ Validation script executable and tested

## Test plan

1. Verify all commands accept `--context` argument:
   ```bash
   /fractary-docs:write api --context "Focus on error handling"
   /fractary-spec:create --work-id 123 --context "Prioritize security"
   /fractary-work:issue-refine 123 --context "Emphasize performance"
   ```

2. Verify agents handle context properly in their workflows

3. Run validation script:
   ```bash
   ./scripts/validate-context-support.sh
   ```

4. Check plugin READMEs display Global Arguments section

🤖 Generated with [Claude Code](https://claude.com/claude-code)