### PR TITLE
feat: Bump plugin and marketplace versions to ensure cache override

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",
-        "version": "2.3.3",
+        "version": "2.3.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -53,7 +53,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with streamlined commands for creating, listing, searching, and updating issues",
-        "version": "2.2.4",
+        "version": "2.2.5",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -91,7 +91,7 @@
         "name": "fractary-file",
         "source": "./plugins/file",
         "description": "Universal file storage operations across R2, S3, and local filesystem with modular handler architecture",
-        "version": "1.2.0",
+        "version": "1.2.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -119,7 +119,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -158,7 +158,7 @@
         "name": "fractary-status",
         "source": "./plugins/status",
         "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-        "version": "1.1.0",
+        "version": "1.1.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -185,7 +185,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "1.1.3",
+        "version": "1.1.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -223,7 +223,7 @@
         "name": "fractary-docs",
         "source": "./plugins/docs",
         "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-docs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
   "agents": [
     "./agents/docs-audit.md",

--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-file",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
   "agents": ["./agents/file-manager.md"],
   "skills": "./skills/",

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Type-aware operational log management - 8 log types with per-type retention, schema validation, and intelligent classification",
   "commands": "./commands/",
   "agents": ["./agents/log-manager.md"],

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-repo",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "./commands/",
   "agents": ["./agents/init.md"],

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": [
     "./commands/init.md",

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-status",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": "./commands/",
   "skills": "./skills/"

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-work",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary
Updated all plugin versions in their individual manifests and the marketplace manifest to ensure recent plugin updates are properly distributed and cached versions are overridden in dependent projects.

## Changes
- Bumped marketplace version: 2.1.4 → 2.1.5
- Updated all 7 plugins with patch version increments
- Ensured version consistency between individual plugin manifests and marketplace listing

## Plugin Versions
- fractary-repo: 2.3.3 → 2.3.4
- fractary-work: 2.2.4 → 2.2.5
- fractary-file: 1.2.0 → 1.2.1
- fractary-logs: 2.1.0 → 2.1.1
- fractary-status: 1.1.0 → 1.1.1
- fractary-spec: 1.1.3 → 1.1.4
- fractary-docs: 2.1.0 → 2.1.1

## Test Plan
- [x] All plugin manifests updated
- [x] Marketplace manifest synchronized with plugin versions
- [x] Version numbers consistent across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)