### PR TITLE
chore: Bump all plugin and marketplace versions by 0.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",
-        "version": "2.4.0",
+        "version": "2.4.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -54,7 +54,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with streamlined commands for creating, listing, searching, and updating issues",
-        "version": "2.2.6",
+        "version": "2.2.7",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -93,7 +93,7 @@
         "name": "fractary-file",
         "source": "./plugins/file",
         "description": "Universal file storage operations across R2, S3, and local filesystem with modular handler architecture",
-        "version": "1.2.1",
+        "version": "1.2.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -121,7 +121,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "2.1.1",
+        "version": "2.1.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -160,7 +160,7 @@
         "name": "fractary-status",
         "source": "./plugins/status",
         "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-        "version": "1.1.1",
+        "version": "1.1.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -187,7 +187,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "1.1.4",
+        "version": "1.1.5",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -225,7 +225,7 @@
         "name": "fractary-docs",
         "source": "./plugins/docs",
         "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-        "version": "2.1.1",
+        "version": "2.1.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-docs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
   "agents": [
     "./agents/docs-audit.md",

--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-file",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
   "agents": ["./agents/file-manager.md"],
   "skills": "./skills/",

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Type-aware operational log management - 8 log types with per-type retention, schema validation, and intelligent classification",
   "commands": "./commands/",
   "agents": ["./agents/log-manager.md"],

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-repo",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": [
     "./commands/init.md",

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-status",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": "./commands/",
   "skills": "./skills/"

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-work",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary
Bumps all plugin versions and the marketplace version by 0.0.1 to ensure cache override following the unified YAML configuration system implementation in PR #27.

## Changes
- Marketplace version: 2.1.7 → 2.1.8
- fractary-repo: 2.4.0 → 2.4.1
- fractary-work: 2.2.6 → 2.2.7
- fractary-file: 1.2.1 → 1.2.2
- fractary-logs: 2.1.1 → 2.1.2
- fractary-status: 1.1.1 → 1.1.2
- fractary-spec: 1.1.4 → 1.1.5
- fractary-docs: 2.1.1 → 2.1.2

Updated both individual plugin manifests (.claude-plugin/plugin.json) and the marketplace registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)