### PR TITLE
fix: Remove non-existent -manager agents and add missing commands to manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,7 +105,7 @@
         "name": "fractary-file",
         "source": "./plugins/file",
         "description": "Universal file storage operations across R2, S3, and local filesystem with modular handler architecture",
-        "version": "1.2.3",
+        "version": "1.2.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -142,7 +142,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "2.1.3",
+        "version": "2.1.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -168,6 +168,7 @@
           "./commands/stop.md",
           "./commands/log.md",
           "./commands/archive.md",
+          "./commands/audit.md",
           "./commands/cleanup.md",
           "./commands/search.md",
           "./commands/analyze.md",
@@ -190,7 +191,7 @@
         "name": "fractary-status",
         "source": "./plugins/status",
         "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-        "version": "1.1.3",
+        "version": "1.1.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -283,7 +284,8 @@
           "./commands/write.md",
           "./commands/validate.md",
           "./commands/list.md",
-          "./commands/audit.md"
+          "./commands/audit.md",
+          "./commands/check-consistency.md"
         ],
         "agents": [
           "./agents/docs-audit.md",

--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "fractary-file",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
-  "agents": ["./agents/file-manager.md"],
+  "agents": "./agents/",
   "skills": "./skills/",
   "commands": "./commands/"
 }

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "fractary-logs",
-  "version": "2.1.2",
+  "version": "2.1.4",
   "description": "Type-aware operational log management - 8 log types with per-type retention, schema validation, and intelligent classification",
   "commands": "./commands/",
-  "agents": ["./agents/log-manager.md"],
+  "agents": "./agents/",
   "skills": "./skills/"
 }

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "fractary-status",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": "./commands/",
+  "agents": "./agents/",
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- Remove non-existent -manager agents (log-manager.md, file-manager.md) from plugin manifests
- Add missing commands to marketplace manifest (audit.md for logs, check-consistency.md for docs)
- Add missing agents field to fractary-status plugin manifest
- Bump patch versions for affected plugins

## Changes
- fractary-logs: v2.1.2 → v2.1.4
- fractary-file: v1.2.2 → v1.2.4
- fractary-status: v1.1.2 → v1.1.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)