### PR TITLE
fix: Remove invalid plugin manifest references and fix version mismatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -216,8 +216,7 @@
         "agents": [
           "./agents/status-install.md",
           "./agents/status-sync.md"
-        ],
-        "hooks": "./hooks/hooks.json"
+        ]
       },
       {
         "name": "fractary-spec",

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-repo",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "1.1.4",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": "./commands/",
-  "agents": "./agents/",
-  "skills": "./skills/"
+  "agents": "./agents/"
 }


### PR DESCRIPTION
## Summary
- Remove non-existent hooks reference from fractary-status in marketplace.json
- Remove non-existent skills directory reference from fractary-status plugin.json
- Update fractary-repo version from 2.5.0 to 2.5.1 in plugin.json to match marketplace.json

These changes resolve doctor command validation errors related to missing plugin files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)