### PR TITLE
chore: Bump versions for S3 upload restoration feature

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -142,7 +142,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "2.1.4",
+        "version": "2.2.0",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -222,7 +222,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "1.1.5",
+        "version": "1.2.0",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Type-aware operational log management - 8 log types with per-type retention, schema validation, and intelligent classification",
   "commands": "./commands/",
   "agents": "./agents/",

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": [
     "./commands/init.md",


### PR DESCRIPTION
## Summary

Version bumps for spec and logs plugins to enable republishing with S3 upload functionality.

**Changes:**
- fractary-spec: 1.1.5 → 1.2.0 (S3 upload, agent-based archival)
- fractary-logs: 2.1.4 → 2.2.0 (S3 upload, agent-based archival)
- fractary-core: 2.2.0 → 2.3.0 (updated marketplace metadata)

**Why:**
- Restored S3 upload functionality broken by v3.0 migration
- Converted archiver skills to agents following best practices
- Added plugin-level scripts for direct S3 integration
- Updated commands to use Task tool invocation pattern

## Test Plan

Already tested in previous commits:
- ✓ spec-archive agent calls S3 upload scripts directly
- ✓ logs-archive agent calls S3 upload scripts directly
- ✓ Both commands follow Task tool best practices
- ✓ Archive indexes sync to S3
- ✓ No CLI/SDK/MCP changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)