### PR TITLE
fix: Correct file plugin manifest format for agents and commands

### DIFF
--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -2,7 +2,17 @@
   "name": "fractary-file",
   "version": "1.2.4",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
-  "agents": "../agents/",
-  "skills": "../skills/",
-  "commands": "../commands/"
+  "commands": [
+    "../commands/init.md",
+    "../commands/show-config.md",
+    "../commands/switch-handler.md",
+    "../commands/test-connection.md"
+  ],
+  "agents": [
+    "../agents/file-init.md",
+    "../agents/file-show-config.md",
+    "../agents/file-switch-handler.md",
+    "../agents/file-test-connection.md"
+  ],
+  "skills": "../skills/"
 }


### PR DESCRIPTION
## Summary
Fixed validation errors in the fractary-file plugin manifest by correcting the format of the `agents` and `commands` fields.

The manifest was using directory string paths instead of arrays of specific file paths, which caused the plugin validator to reject the manifest with "agents: Invalid input" error.

## Changes
- Updated `agents` field from `"../agents/"` to an array of 4 specific agent markdown files
- Updated `commands` field from `"../commands/"` to an array of 4 specific command markdown files
- Aligned with the format used in other plugins (fractary-work, fractary-repo, fractary-spec, etc.)

## Testing
The plugin should now load without validation errors when running `/doctor` or loading the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)