### PR TITLE
fix: Correct plugin manifests and bump versions

### DIFF
--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-file",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
   "commands": [
     "../commands/init.md",

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,8 +1,30 @@
 {
   "name": "fractary-logs",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Type-aware operational log management - 8 log types with per-type retention, schema validation, and intelligent classification",
-  "commands": "../commands/",
-  "agents": "../agents/",
+  "commands": [
+    "../commands/analyze.md",
+    "../commands/archive.md",
+    "../commands/audit.md",
+    "../commands/capture.md",
+    "../commands/cleanup.md",
+    "../commands/init.md",
+    "../commands/log.md",
+    "../commands/read.md",
+    "../commands/search.md",
+    "../commands/stop.md"
+  ],
+  "agents": [
+    "../agents/logs-analyze.md",
+    "../agents/logs-archive.md",
+    "../agents/logs-audit.md",
+    "../agents/logs-capture.md",
+    "../agents/logs-cleanup.md",
+    "../agents/logs-init.md",
+    "../agents/logs-log.md",
+    "../agents/logs-read.md",
+    "../agents/logs-search.md",
+    "../agents/logs-stop.md"
+  ],
   "skills": "../skills/"
 }


### PR DESCRIPTION
## Summary
- fractary-logs: Convert commands and agents from directory strings to arrays of specific file paths
- fractary-file: Bump version to force cache refresh for manifest validation

Fixes validation errors reported by /doctor command for both plugins.

## Test plan
- [ ] Run `/doctor` command and verify no validation errors
- [ ] Verify both plugins load correctly