### PR TITLE
chore: Bump plugin versions (file 1.2.7, logs 2.2.2, core 2.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -105,7 +105,7 @@
         "name": "fractary-file",
         "source": "./plugins/file",
         "description": "Universal file storage operations across R2, S3, and local filesystem with modular handler architecture",
-        "version": "1.2.5",
+        "version": "1.2.7",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -142,7 +142,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "2.2.0",
+        "version": "2.2.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-file",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
   "commands": [
     "../commands/init.md",

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Type-aware operational log management - 8 log types with per-type retention, schema validation, and intelligent classification",
   "commands": [
     "../commands/analyze.md",


### PR DESCRIPTION
Updates plugin versions in marketplace and plugin manifests.