### PR TITLE
fix: Normalize plugin manifests to consistent directory format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",
-        "version": "2.5.1",
+        "version": "2.5.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -60,7 +60,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with bulk creation, refinement, and streamlined commands for creating, listing, searching, and updating issues",
-        "version": "2.3.0",
+        "version": "2.3.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -222,7 +222,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "1.2.0",
+        "version": "1.2.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -260,7 +260,7 @@
         "name": "fractary-docs",
         "source": "./plugins/docs",
         "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-        "version": "2.2.0",
+        "version": "2.2.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,14 +1,8 @@
 {
   "name": "fractary-docs",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-  "agents": [
-    "../agents/docs-audit.md",
-    "../agents/docs-check-consistency.md",
-    "../agents/docs-list.md",
-    "../agents/docs-validate.md",
-    "../agents/docs-write.md"
-  ],
-  "skills": "../skills/",
-  "commands": "../commands/"
+  "commands": "../commands/",
+  "agents": "../agents/",
+  "skills": "../skills/"
 }

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,11 +1,8 @@
 {
   "name": "fractary-repo",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "../commands/",
-  "agents": [
-    "../agents/init.md",
-    "../agents/pr-review-agent.md"
-  ],
+  "agents": "../agents/",
   "skills": "../skills/"
 }

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,20 +1,8 @@
 {
   "name": "fractary-spec",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-  "commands": [
-    "../commands/init.md",
-    "../commands/create.md",
-    "../commands/refine.md",
-    "../commands/validate.md",
-    "../commands/archive.md"
-  ],
-  "agents": [
-    "../agents/spec-archive.md",
-    "../agents/spec-create.md",
-    "../agents/spec-init.md",
-    "../agents/spec-refine.md",
-    "../agents/spec-validate.md"
-  ],
+  "commands": "../commands/",
+  "agents": "../agents/",
   "skills": "../skills/"
 }

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,12 +1,8 @@
 {
   "name": "fractary-work",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "../commands/",
-  "agents": [
-    "../agents/init.md",
-    "../agents/issue-refine.md",
-    "../agents/issue-bulk-creator.md"
-  ],
+  "agents": "../agents/",
   "skills": "../skills/"
 }


### PR DESCRIPTION
## Summary

Normalizes all plugin manifest files to use directory strings for commands and agents fields instead of mixed array/directory formats. Claude Code's plugin validation expects the directory format used by working plugins (repo, work, logs, file).

## Changes

- **fractary-repo**: Convert agents array to directory string, bump 2.5.1 → 2.5.2
- **fractary-work**: Convert agents array to directory string, bump 2.3.0 → 2.3.1
- **fractary-spec**: Convert commands and agents arrays to directory strings, bump 1.2.0 → 1.2.1
- **fractary-docs**: Convert agents array to directory string, bump 2.2.0 → 2.2.1
- **marketplace.json**: Update all plugin versions to force cache refresh, bump core 2.3.2 → 2.3.3

## Root Cause

Previous fixes created inconsistent formats across plugins. Some used directory strings (logs, file, working), others used arrays (repo, work, spec, docs). Claude Code validation requires directory format consistently.

## Testing

All plugin manifests now validate successfully:
- ✅ fractary-repo: `agents: "../agents/"`
- ✅ fractary-work: `agents: "../agents/"`
- ✅ fractary-spec: `commands: "../commands/"`, `agents: "../agents/"`
- ✅ fractary-docs: `agents: "../agents/"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)