### PR TITLE
feat: Restore fractary-core plugins to project configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,12 +115,28 @@
       ]
     }
   },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/plugins/marketplaces/fractary-core/plugins/status/scripts/status-line.sh"
+  },
   "enabledPlugins": {
     "fractary-codex@fractary-codex": true,
+    "fractary-repo@fractary-core": true,
+    "fractary-work@fractary-core": true,
+    "fractary-docs@fractary-core": true,
+    "fractary-spec@fractary-core": true,
+    "fractary-logs@fractary-core": true,
+    "fractary-file@fractary-core": true,
     "fractary-faber@fractary-faber": true,
     "fractary-faber-cloud@fractary-faber": true
   },
   "extraKnownMarketplaces": {
+    "fractary-core": {
+      "source": {
+        "source": "github",
+        "repo": "fractary/core"
+      }
+    },
     "fractary-codex": {
       "source": {
         "source": "github",


### PR DESCRIPTION
## Summary
Re-enables fractary-core plugins in the project-level `.claude/settings.json` now that plugin manifest validation issues have been resolved.

## Changes
- Restored all fractary-core plugins to `enabledPlugins` (repo, work, docs, spec, logs, file)
- Added fractary-core to `extraKnownMarketplaces` for GitHub-based sync
- Added statusLine configuration for the fractary-core status plugin

## Context
The plugins were previously removed from project settings due to manifest validation errors. Those errors have been fixed by correcting the plugin.json format to use proper `./` path prefixes and including the `skills` field, matching the working format from fractary-codex and fractary-faber.

## Verification
- All fractary-core plugins load without validation errors
- Project-level and user-level plugin management now work correctly together
- Status line displays git and plugin information as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)