### PR TITLE
fix: Register fractary-core plugin in marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,33 @@
     },
     "plugins": [
       {
+        "name": "fractary-core",
+        "source": "./plugins/core",
+        "description": "Core initialization and configuration for Fractary plugins",
+        "version": "3.0.0",
+        "author": {
+          "name": "The Fractary",
+          "url": "https://github.com/fractary"
+        },
+        "homepage": "https://github.com/fractary/core/tree/main/plugins/core",
+        "repository": "https://github.com/fractary/core/tree/main/plugins/core",
+        "license": "MIT",
+        "keywords": [
+          "configuration",
+          "initialization",
+          "setup",
+          "core"
+        ],
+        "category": "development",
+        "strict": true,
+        "commands": [
+          "./commands/init.md"
+        ],
+        "agents": [
+          "./agents/config-manager.md"
+        ]
+      },
+      {
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "fractary-core",
+  "version": "3.0.0",
+  "description": "Core initialization and configuration for Fractary plugins",
+  "commands": "./commands/",
+  "agents": [
+    "./agents/config-manager.md"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add missing fractary-core plugin entry to marketplace.json
- Create plugin.json for core plugin to match other plugin structure
- Fixes issue where /fractary-core:init command was unavailable after consolidation

## Details
The consolidated init system (commit 4b0854a) removed init commands from individual plugins but never registered the new fractary-core plugin in the marketplace manifest. This prevented the /fractary-core:init command from being discoverable and available to users.

Changes:
- Added fractary-core plugin entry to .claude-plugin/marketplace.json with proper command and agent registrations
- Created plugins/core/.claude-plugin/plugin.json following the same pattern as other core plugins
- Both set to version 3.0.0 to match the marketplace version bump

## Test plan
- [ ] Run `/plugin marketplace update fractary-core`
- [ ] Verify `/fractary-core:init` command is now available
- [ ] Verify individual plugin init commands are no longer available

🤖 Generated with [Claude Code](https://claude.com/claude-code)