### PR TITLE
Fix CLI publish error

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core-cli",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@fractary/core": "^0.1.0",
+        "@fractary/core": "^0.3.0",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.5",
         "commander": "^11.1.0",
@@ -36,7 +36,7 @@
     },
     "../sdk/js": {
       "name": "@fractary/core",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.1",
@@ -53,7 +53,8 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^1.0.4"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -4,6 +4,17 @@
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "common/yaml-config": ["dist/common/yaml-config.d.ts"],
+      "work": ["dist/work/index.d.ts"],
+      "repo": ["dist/repo/index.d.ts"],
+      "spec": ["dist/spec/index.d.ts"],
+      "logs": ["dist/logs/index.d.ts"],
+      "file": ["dist/file/index.d.ts"],
+      "docs": ["dist/docs/index.d.ts"]
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -32,6 +43,10 @@
     "./docs": {
       "types": "./dist/docs/index.d.ts",
       "default": "./dist/docs/index.js"
+    },
+    "./common/yaml-config": {
+      "types": "./dist/common/yaml-config.d.ts",
+      "default": "./dist/common/yaml-config.js"
     }
   },
   "files": [

--- a/sdk/js/src/common/types.ts
+++ b/sdk/js/src/common/types.ts
@@ -331,11 +331,6 @@ export interface WorktreeCreateOptions {
   workId?: string;
 }
 
-export interface BranchCreateOptions {
-  branch: string;
-  baseBranch?: string;
-}
-
 export interface BranchCreateResult {
   success: boolean;
   branch: string;


### PR DESCRIPTION
- Add typesVersions and exports for common/yaml-config in SDK package.json to fix TS2307 "Cannot find module" errors when importing from @fractary/core/common/yaml-config

- Remove duplicate BranchCreateOptions interface from types.ts The second definition at line 334 required a 'branch' property and overwrote the first proper definition, causing TS2345 type errors in CLI repo/branch.ts