### PR TITLE
Set default merge options for fractary-repo

### DIFF
--- a/plugins/core/agents/config-manager.md
+++ b/plugins/core/agents/config-manager.md
@@ -1644,6 +1644,9 @@ repo:
         interval_seconds: 60
         timeout_seconds: 900
         initial_delay_seconds: 10
+      merge:
+        strategy: squash
+        delete_branch: true
   faber_integration:
     enabled: true
     branch_creation:

--- a/plugins/repo/commands/pr-merge.md
+++ b/plugins/repo/commands/pr-merge.md
@@ -8,6 +8,7 @@ argument-hint: '<pr_number> [--squash|--merge|--rebase] [--delete-branch] [--con
 ## Context
 
 - Repository: !`gh repo view --json nameWithOwner -q .nameWithOwner`
+- Config defaults: !`cat .fractary/config.yaml 2>/dev/null | grep -A5 'pr:' | grep -A2 'merge:' | grep -E '(strategy|delete_branch):' | tr '\n' ' ' || echo "strategy: squash delete_branch: true"`
 
 ## Your task
 
@@ -15,8 +16,14 @@ Merge pull request using `gh pr merge`.
 
 Parse arguments:
 - pr_number (required)
-- strategy: --squash, --merge, or --rebase (default: merge)
-- --delete-branch if requested
+- strategy: --squash, --merge, or --rebase
+- --delete-branch flag
+
+**Default behavior**: If no strategy flag (--squash, --merge, --rebase) is provided, use the configured default from `.fractary/config.yaml` at `repo.defaults.pr.merge.strategy`. If no --delete-branch flag is provided, check the configured default at `repo.defaults.pr.merge.delete_branch`.
+
+The config defaults shown above indicate the configured values. If the config could not be read, the fallback defaults are: strategy=squash, delete_branch=true.
+
+**Priority**: Explicit command-line flags always override config defaults.
 
 Example: `gh pr merge 42 --squash --delete-branch`
 

--- a/plugins/repo/config/repo.example.json
+++ b/plugins/repo/config/repo.example.json
@@ -111,6 +111,13 @@
         "$comment_timeout": "Maximum seconds to wait for CI (default: 900 = 15 minutes)",
         "initial_delay_seconds": 10,
         "$comment_initial_delay": "Initial delay before first check (allows CI to start)"
+      },
+
+      "merge": {
+        "strategy": "squash",
+        "$comment_strategy": "Default merge strategy for PRs: squash|merge|rebase",
+        "delete_branch": true,
+        "$comment_delete": "Delete branch after merge by default"
       }
     },
 

--- a/sdk/js/src/common/yaml-config.ts
+++ b/sdk/js/src/common/yaml-config.ts
@@ -21,12 +21,56 @@ export interface WorkConfig {
 }
 
 /**
+ * PR merge default options
+ */
+export interface PRMergeDefaults {
+  /** Default merge strategy: 'squash', 'merge', or 'rebase' */
+  strategy?: 'squash' | 'merge' | 'rebase';
+  /** Whether to delete the branch after merge by default */
+  delete_branch?: boolean;
+}
+
+/**
+ * PR configuration defaults
+ */
+export interface PRDefaults {
+  template?: string;
+  require_work_id?: boolean;
+  auto_link_issues?: boolean;
+  ci_polling?: {
+    enabled?: boolean;
+    interval_seconds?: number;
+    timeout_seconds?: number;
+    initial_delay_seconds?: number;
+  };
+  /** Default options for PR merge operations */
+  merge?: PRMergeDefaults;
+}
+
+/**
+ * Repository defaults configuration
+ */
+export interface RepoDefaults {
+  default_branch?: string;
+  protected_branches?: string[];
+  branch_naming?: Record<string, any>;
+  commit_format?: string;
+  require_signed_commits?: boolean;
+  merge_strategy?: string;
+  auto_delete_merged_branches?: boolean;
+  remote?: Record<string, any>;
+  push_sync_strategy?: string;
+  pull_sync_strategy?: string;
+  pr?: PRDefaults;
+}
+
+/**
  * Repository management configuration
  */
 export interface RepoConfig {
   active_handler: string;
   handlers: Record<string, any>;
-  defaults?: Record<string, any>;
+  defaults?: RepoDefaults;
   faber_integration?: Record<string, any>;
   hooks?: Record<string, any>;
   platform_specific?: Record<string, any>;


### PR DESCRIPTION
- Add PRMergeDefaults, PRDefaults, and RepoDefaults interfaces to yaml-config.ts
- Update pr-merge.md to read defaults from config.yaml (repo.defaults.pr.merge)
- Set default merge strategy to 'squash' and delete_branch to true in config-manager.md
- Update repo.example.json with merge configuration documentation

Users can now configure their preferred PR merge behavior in .fractary/config.yaml and the pr-merge command will use those defaults automatically. Explicit command-line flags still override config defaults.