### PR TITLE
chore: Patch bump all versions across SDK, CLI, MCP, and plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-core",
         "source": "./plugins/core",
         "description": "Core initialization and configuration for Fractary plugins",
-        "version": "3.1.2",
+        "version": "3.1.3",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -42,7 +42,7 @@
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",
-        "version": "3.0.2",
+        "version": "3.0.3",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -85,7 +85,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with bulk creation, refinement, and streamlined commands for creating, listing, searching, and updating issues",
-        "version": "3.0.2",
+        "version": "3.0.3",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -128,7 +128,7 @@
         "name": "fractary-file",
         "source": "./plugins/file",
         "description": "Universal file storage operations across R2, S3, and local filesystem with modular handler architecture",
-        "version": "2.0.2",
+        "version": "2.0.3",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -163,7 +163,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "3.0.3",
+        "version": "4.0.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -210,7 +210,7 @@
         "name": "fractary-status",
         "source": "./plugins/status",
         "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-        "version": "1.1.6",
+        "version": "1.1.7",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -241,7 +241,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "2.0.3",
+        "version": "2.0.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -277,7 +277,7 @@
         "name": "fractary-docs",
         "source": "./plugins/docs",
         "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-        "version": "2.2.7",
+        "version": "3.0.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/mcp/server/package.json
+++ b/mcp/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP server for Fractary Core SDK - universal tool access for work, repo, spec, logs, file, docs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-core",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Core initialization and configuration for Fractary plugins",
   "commands": "./commands/",
   "agents": [

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-docs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Documentation system with per-type skills for Claude auto-discovery. Each document type (ADR, API, architecture, etc.) has its own skill with synonyms for natural language matching.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-file",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
   "commands": "./commands/",
   "agents": [

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Log management with per-type skills for Claude auto-discovery. Each log type (session, build, deployment, etc.) has its own skill with synonyms for natural language matching.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-repo",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": "./commands/",
   "agents": [

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-status",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": "../commands/",
   "agents": "../agents/"

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-work",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "./commands/",
   "agents": [

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Patch bump all version numbers across the SDK, CLI, MCP server, and all plugins to reflect recent enhancements and prepare for republication to npm and marketplace.

## Changes
- SDK (@fractary/core): 0.3.1 → 0.3.2
- CLI (@fractary/core-cli): 0.2.1 → 0.2.2
- MCP Server (@fractary/core-mcp): 0.2.1 → 0.2.2
- fractary-core plugin: 3.1.2 → 3.1.3
- fractary-repo plugin: 3.0.2 → 3.0.3
- fractary-work plugin: 3.0.2 → 3.0.3
- fractary-file plugin: 2.0.2 → 2.0.3
- fractary-logs plugin: 4.0.0 → 4.0.1
- fractary-status plugin: 1.1.6 → 1.1.7
- fractary-spec plugin: 2.0.3 → 2.0.4
- fractary-docs plugin: 3.0.0 → 3.0.1
- Marketplace manifest: 3.1.2 → 3.1.3

Also synced marketplace.json plugin versions with plugin.json files to ensure consistency across all plugin declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)