### PR TITLE
fix(plugins): Correct manifest file references and increment versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-core",
         "source": "./plugins/core",
         "description": "Core initialization and configuration for Fractary plugins",
-        "version": "3.1.3",
+        "version": "3.1.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -32,10 +32,10 @@
         "category": "development",
         "strict": true,
         "commands": [
-          "./commands/init.md"
+          "./commands/configure.md"
         ],
         "agents": [
-          "./agents/config-manager.md"
+          "./agents/configurator.md"
         ]
       },
       {
@@ -210,7 +210,7 @@
         "name": "fractary-status",
         "source": "./plugins/status",
         "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-        "version": "1.1.7",
+        "version": "1.1.8",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,9 +1,11 @@
 {
   "name": "fractary-core",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Core initialization and configuration for Fractary plugins",
-  "commands": "./commands/",
+  "commands": [
+    "./commands/configure.md"
+  ],
   "agents": [
-    "./agents/config-manager.md"
+    "./agents/configurator.md"
   ]
 }

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,7 +1,13 @@
 {
   "name": "fractary-status",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-  "commands": "../commands/",
-  "agents": "../agents/"
+  "commands": [
+    "../commands/install.md",
+    "../commands/sync.md"
+  ],
+  "agents": [
+    "../agents/status-install.md",
+    "../agents/status-sync.md"
+  ]
 }


### PR DESCRIPTION
## Summary
- Fixed fractary-core manifest: corrected agent and command file references, converted to array format
- Fixed fractary-status manifest: converted commands and agents from directory paths to file arrays
- Incremented versions: fractary-core 3.1.3→3.1.4, fractary-status 1.1.7→1.1.8
- Updated marketplace.json with new plugin versions

## Test plan
- [x] Verify manifest files reference actual files that exist
- [x] Confirm JSON syntax is valid
- [x] Test plugin installation after cache clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)