### PR TITLE
fix(plugins): Correct fractary-status plugin manifest path format

### DIFF
--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "fractary-status",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": [
-    "../commands/install.md",
-    "../commands/sync.md"
+    "./commands/install.md",
+    "./commands/sync.md"
   ],
   "agents": [
-    "../agents/status-install.md",
-    "../agents/status-sync.md"
+    "./agents/status-install.md",
+    "./agents/status-sync.md"
   ]
 }


### PR DESCRIPTION
Changed command and agent paths from parent-directory relative (../) to plugin-root relative (./) to match Claude Code's plugin loader expectations. Also bumped version to 1.1.9.