### PR TITLE
Clarify post-merge actions for package publishing

### DIFF
--- a/plugins/repo/commands/pr-merge.md
+++ b/plugins/repo/commands/pr-merge.md
@@ -27,4 +27,65 @@ The config defaults shown above indicate the configured values. If the config co
 
 Example: `gh pr merge 42 --squash --delete-branch`
 
-You have the capability to call multiple tools in a single response. Execute the merge operation in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.
+## Execution steps
+
+1. First, get the list of changed files in the PR:
+   ```
+   gh pr view <pr_number> --json files -q '.files[].path'
+   ```
+
+2. Execute the merge operation using `gh pr merge` with the appropriate flags.
+
+3. After a successful merge, analyze the changed files and output a **Required Actions** section.
+
+## Required Actions Analysis
+
+After successful merge, analyze which directories were changed and output required follow-up actions:
+
+### Packages requiring npm publish
+
+| Directory Pattern | Package | Action |
+|------------------|---------|--------|
+| `sdk/js/**` | `@fractary/core` | `cd sdk/js && npm publish` |
+| `cli/**` | `@fractary/core-cli` | `cd cli && npm publish` |
+| `mcp/server/**` | `@fractary/core-mcp` | `cd mcp/server && npm publish` |
+
+### Plugins requiring sync/update
+
+| Directory Pattern | Plugin | Action |
+|------------------|--------|--------|
+| `plugins/core/**` | fractary-core | `/Fractary-Core-Configure` |
+| `plugins/repo/**` | fractary-repo | Reinstall plugin or restart Claude Code |
+| `plugins/work/**` | fractary-work | Reinstall plugin or restart Claude Code |
+| `plugins/file/**` | fractary-file | Reinstall plugin or restart Claude Code |
+| `plugins/logs/**` | fractary-logs | Reinstall plugin or restart Claude Code |
+| `plugins/spec/**` | fractary-spec | Reinstall plugin or restart Claude Code |
+| `plugins/docs/**` | fractary-docs | Reinstall plugin or restart Claude Code |
+| `plugins/status/**` | fractary-status | `/Fractary-Status-Sync` |
+
+## Output format
+
+After successful merge, output the following:
+
+```
+✓ PR #<number> merged successfully
+
+## Required Actions
+
+<Only list sections that apply based on changed files>
+
+### Packages to Republish
+- [ ] `@fractary/core` - run `cd sdk/js && npm publish`
+- [ ] `@fractary/core-cli` - run `cd cli && npm publish`
+- [ ] `@fractary/core-mcp` - run `cd mcp/server && npm publish`
+
+### Plugins to Update
+- [ ] fractary-<name> - <action>
+```
+
+If no packages or plugins were changed, output:
+```
+✓ PR #<number> merged successfully
+
+No packages or plugins require updates.
+```


### PR DESCRIPTION
After merging a PR, the command now analyzes changed files and outputs a checklist of required follow-up actions:
- Packages to republish (SDK, CLI, MCP server)
- Plugins to sync/update

This helps users understand what additional steps are needed when packages or plugins are modified in a PR.