### PR TITLE
Bump @fractary/core to 0.6.2 and add config documentation

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -44,7 +44,7 @@
   "author": "Fractary Team",
   "license": "MIT",
   "dependencies": {
-    "@fractary/core": "^0.6.0",
+    "@fractary/core": "^0.6.2",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^11.1.0",

--- a/mcp/server/package.json
+++ b/mcp/server/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/fractary/core/tree/main/mcp/server#readme",
   "dependencies": {
-    "@fractary/core": "^0.6.0",
+    "@fractary/core": "^0.6.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "js-yaml": "^4.1.1",
     "minimatch": "^10.1.1"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/src/config/index.ts
+++ b/sdk/js/src/config/index.ts
@@ -21,14 +21,19 @@ export {
 export {
   loadYamlConfig,
   writeYamlConfig,
+  injectDocumentationComments,
   findProjectRoot,
   configExists,
   getConfigPath,
   getCoreDir,
   substituteEnvVars,
   validateEnvVars,
+  // Documentation URL constants for config sections
+  PLUGIN_DOC_URLS,
+  CONFIG_GUIDE_URL,
   type CoreYamlConfig,
   type ConfigLoadOptions,
+  type WriteYamlConfigOptions,
   // Rename to avoid conflicts with runtime types from common/types.ts
   type WorkConfig as YamlWorkConfig,
   type RepoConfig as YamlRepoConfig,


### PR DESCRIPTION
## Summary
This release bumps the `@fractary/core` package to version 0.6.2 across all dependent packages and adds comprehensive documentation URL support to the YAML configuration system.

## Key Changes

- **Version Bump**: Updated `@fractary/core` from 0.6.0 to 0.6.2 in:
  - `cli/package.json`
  - `mcp/server/package.json`
  - `sdk/js/package.json` (source package version)

- **Documentation URL Constants**: Added `PLUGIN_DOC_URLS` and `CONFIG_GUIDE_URL` constants that map configuration sections to their GitHub documentation pages

- **Enhanced Config Writing**: 
  - Added `injectDocumentationComments()` function that automatically injects documentation URL comments into generated YAML configuration files
  - Updated `writeYamlConfig()` to accept an options object with `includeDocComments` flag (enabled by default)
  - Maintains backward compatibility by accepting either a string (projectRoot) or options object

- **Improved Documentation**: 
  - Added JSDoc comments explaining the new documentation injection feature
  - Exported new types and constants for public API use

## Implementation Details

The `injectDocumentationComments()` function intelligently adds documentation comments by:
- Detecting top-level configuration sections (work, repo, logs, file, spec, docs, codex)
- Only adding comments for sections that exist in the actual configuration
- Prepending a header comment with the main configuration guide URL
- Maintaining proper YAML formatting and readability

The changes are fully backward compatible - existing code using `writeYamlConfig(projectRoot)` will continue to work as before.