### PR TITLE
Remove auto-archive configuration from logs and specs

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -44,7 +44,7 @@
   "author": "Fractary Team",
   "license": "MIT",
   "dependencies": {
-    "@fractary/core": "^0.7.3",
+    "@fractary/core": "^0.7.4",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^11.1.0",

--- a/cli/src/commands/logs/index.ts
+++ b/cli/src/commands/logs/index.ts
@@ -139,8 +139,6 @@ function createLogsTypeInfoCommand(): Command {
               ? {
                   default_local_days: type.retention.defaultLocalDays,
                   default_cloud_days: type.retention.defaultCloudDays,
-                  auto_archive: type.retention.autoArchive,
-                  cleanup_after_archive: type.retention.cleanupAfterArchive,
                 }
               : undefined,
           };

--- a/mcp/server/package.json
+++ b/mcp/server/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/fractary/core/tree/main/mcp/server#readme",
   "dependencies": {
-    "@fractary/core": "^0.7.3",
+    "@fractary/core": "^0.7.4",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "js-yaml": "^4.1.1",
     "minimatch": "^10.1.1"

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Log management with per-type skills for Claude auto-discovery. Each log type (session, build, deployment, etc.) has its own skill with synonyms for natural language matching.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/logs/config/config.example.json
+++ b/plugins/logs/config/config.example.json
@@ -16,9 +16,7 @@
     "default": {
       "local_days": 30,
       "cloud_days": "forever",
-      "priority": "medium",
-      "auto_archive": true,
-      "cleanup_after_archive": true
+      "priority": "medium"
     },
     "paths": [
       {
@@ -27,17 +25,10 @@
         "local_days": 7,
         "cloud_days": "forever",
         "priority": "high",
-        "auto_archive": true,
-        "cleanup_after_archive": false,
         "retention_exceptions": {
           "keep_if_linked_to_open_issue": true,
           "keep_if_referenced_in_docs": true,
           "keep_recent_n": 10
-        },
-        "archive_triggers": {
-          "age_days": 7,
-          "size_mb": null,
-          "status": ["stopped", "error"]
         },
         "validation": {
           "require_summary": true,
@@ -62,16 +53,9 @@
         "local_days": 3,
         "cloud_days": 30,
         "priority": "medium",
-        "auto_archive": true,
-        "cleanup_after_archive": true,
         "retention_exceptions": {
           "keep_if_linked_to_open_issue": true,
           "keep_recent_n": 5
-        },
-        "archive_triggers": {
-          "age_days": 3,
-          "size_mb": null,
-          "status": ["success", "failure", "cancelled"]
         },
         "validation": {
           "require_summary": true,
@@ -96,18 +80,11 @@
         "local_days": 30,
         "cloud_days": "forever",
         "priority": "critical",
-        "auto_archive": true,
-        "cleanup_after_archive": false,
         "retention_exceptions": {
           "keep_if_linked_to_open_issue": true,
           "keep_if_referenced_in_docs": true,
           "keep_recent_n": 20,
           "never_delete_production": true
-        },
-        "archive_triggers": {
-          "age_days": 30,
-          "size_mb": null,
-          "status": ["success", "failure", "rolled_back"]
         },
         "validation": {
           "require_summary": true,
@@ -133,16 +110,9 @@
         "local_days": 3,
         "cloud_days": 7,
         "priority": "low",
-        "auto_archive": true,
-        "cleanup_after_archive": true,
         "retention_exceptions": {
           "keep_if_linked_to_open_issue": true,
           "keep_recent_n": 3
-        },
-        "archive_triggers": {
-          "age_days": 3,
-          "size_mb": null,
-          "status": ["success", "failure"]
         },
         "validation": {
           "require_summary": false,
@@ -166,16 +136,9 @@
         "local_days": 7,
         "cloud_days": 30,
         "priority": "medium",
-        "auto_archive": true,
-        "cleanup_after_archive": true,
         "retention_exceptions": {
           "keep_if_linked_to_open_issue": true,
           "keep_recent_n": 5
-        },
-        "archive_triggers": {
-          "age_days": 7,
-          "size_mb": null,
-          "status": ["stopped", "error"]
         },
         "validation": {
           "require_summary": false,
@@ -199,18 +162,11 @@
         "local_days": 90,
         "cloud_days": "forever",
         "priority": "critical",
-        "auto_archive": true,
-        "cleanup_after_archive": false,
         "retention_exceptions": {
           "keep_if_referenced_in_docs": true,
           "keep_recent_n": 100,
           "never_delete_security_incidents": true,
           "never_delete_compliance_audits": true
-        },
-        "archive_triggers": {
-          "age_days": 90,
-          "size_mb": null,
-          "status": ["completed"]
         },
         "validation": {
           "require_summary": true,
@@ -234,15 +190,8 @@
         "local_days": 14,
         "cloud_days": 90,
         "priority": "medium",
-        "auto_archive": true,
-        "cleanup_after_archive": true,
         "retention_exceptions": {
           "keep_recent_n": 10
-        },
-        "archive_triggers": {
-          "age_days": 14,
-          "size_mb": null,
-          "status": ["completed"]
         },
         "validation": {
           "require_summary": false,
@@ -266,16 +215,9 @@
         "local_days": 7,
         "cloud_days": "forever",
         "priority": "high",
-        "auto_archive": true,
-        "cleanup_after_archive": false,
         "retention_exceptions": {
           "keep_if_linked_to_open_issue": true,
           "keep_recent_n": 20
-        },
-        "archive_triggers": {
-          "age_days": 7,
-          "size_mb": null,
-          "status": ["completed", "failed"]
         },
         "validation": {
           "require_summary": true,
@@ -299,16 +241,9 @@
         "local_days": 7,
         "cloud_days": "forever",
         "priority": "high",
-        "auto_archive": true,
-        "cleanup_after_archive": false,
         "retention_exceptions": {
           "keep_if_referenced_in_docs": true,
           "keep_recent_n": 50
-        },
-        "archive_triggers": {
-          "age_days": 7,
-          "size_mb": null,
-          "status": ["published"]
         },
         "validation": {
           "require_summary": false,
@@ -344,11 +279,6 @@
     "format": "markdown"
   },
   "archive": {
-    "auto_archive_on": {
-      "work_complete": true,
-      "issue_close": true,
-      "manual_trigger": true
-    },
     "compression": {
       "enabled": true,
       "format": "gzip",
@@ -388,8 +318,7 @@
       "comment_on_archive": true
     },
     "faber": {
-      "auto_capture": true,
-      "auto_archive_on_complete": true
+      "auto_capture": true
     }
   },
   "docs_integration": {

--- a/plugins/logs/config/config.schema.json
+++ b/plugins/logs/config/config.schema.json
@@ -81,14 +81,6 @@
               "type": "string",
               "enum": ["critical", "high", "medium", "low"],
               "description": "Retention priority level"
-            },
-            "auto_archive": {
-              "type": "boolean",
-              "description": "Enable automatic archival for this log type"
-            },
-            "cleanup_after_archive": {
-              "type": "boolean",
-              "description": "Remove from local storage after successful archival"
             }
           }
         },
@@ -125,14 +117,6 @@
                 "enum": ["critical", "high", "medium", "low"],
                 "description": "Retention priority level"
               },
-              "auto_archive": {
-                "type": "boolean",
-                "description": "Enable automatic archival for this log type"
-              },
-              "cleanup_after_archive": {
-                "type": "boolean",
-                "description": "Remove from local storage after successful archival"
-              },
               "retention_exceptions": {
                 "type": "object",
                 "description": "Special rules to prevent deletion",
@@ -161,30 +145,6 @@
                   "never_delete_compliance_audits": {
                     "type": "boolean",
                     "description": "Never delete compliance audit logs"
-                  }
-                }
-              },
-              "archive_triggers": {
-                "type": "object",
-                "description": "Conditions that trigger automatic archival",
-                "properties": {
-                  "age_days": {
-                    "type": "number",
-                    "minimum": 1,
-                    "description": "Archive when log reaches this age in days"
-                  },
-                  "size_mb": {
-                    "type": ["number", "null"],
-                    "minimum": 0.1,
-                    "description": "Archive when log exceeds this size in MB (null = no size trigger)"
-                  },
-                  "status": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "enum": ["stopped", "error", "success", "failure", "cancelled", "rolled_back"]
-                    },
-                    "description": "Archive when log has one of these status values"
                   }
                 }
               },
@@ -326,14 +286,6 @@
     "archive": {
       "type": "object",
       "properties": {
-        "auto_archive_on": {
-          "type": "object",
-          "properties": {
-            "work_complete": {"type": "boolean"},
-            "issue_close": {"type": "boolean"},
-            "manual_trigger": {"type": "boolean"}
-          }
-        },
         "compression": {
           "type": "object",
           "properties": {
@@ -413,8 +365,7 @@
         "faber": {
           "type": "object",
           "properties": {
-            "auto_capture": {"type": "boolean"},
-            "auto_archive_on_complete": {"type": "boolean"}
+            "auto_capture": {"type": "boolean"}
           }
         }
       }

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": "./commands/",
   "agents": [

--- a/plugins/spec/config/config.example.json
+++ b/plugins/spec/config/config.example.json
@@ -20,11 +20,6 @@
   },
   "archive": {
     "strategy": "lifecycle",
-    "auto_archive_on": {
-      "issue_close": true,
-      "pr_merge": true,
-      "faber_release": true
-    },
     "pre_archive": {
       "check_docs_updated": "warn",
       "prompt_user": true,

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/src/config/defaults.test.ts
+++ b/sdk/js/src/config/defaults.test.ts
@@ -357,7 +357,6 @@ describe('getDefaultConfig', () => {
       const archive = config.spec?.archive;
 
       expect(archive?.strategy).toBe('lifecycle');
-      expect(archive?.auto_archive_on?.issue_close).toBe(true);
     });
   });
 

--- a/sdk/js/src/config/defaults.ts
+++ b/sdk/js/src/config/defaults.ts
@@ -187,8 +187,6 @@ function getDefaultLogsConfig(options: DefaultConfigOptions): LogsConfig {
         local_days: 30,
         ...(useS3 && { cloud_days: 'forever' }),
         priority: 'medium',
-        auto_archive: useS3,
-        cleanup_after_archive: useS3,
       },
       paths: [
         {
@@ -197,8 +195,6 @@ function getDefaultLogsConfig(options: DefaultConfigOptions): LogsConfig {
           local_days: 7,
           ...(useS3 && { cloud_days: 'forever' }),
           priority: 'high',
-          auto_archive: useS3,
-          cleanup_after_archive: false,
         },
       ],
     },
@@ -330,11 +326,6 @@ function getDefaultSpecConfig(options: DefaultConfigOptions): SpecConfig {
     },
     archive: {
       strategy: 'lifecycle',
-      auto_archive_on: {
-        issue_close: true,
-        pr_merge: true,
-        faber_release: true,
-      },
     },
     integration: {
       work_plugin: 'fractary-work',

--- a/sdk/js/src/logs/type-registry.test.ts
+++ b/sdk/js/src/logs/type-registry.test.ts
@@ -82,8 +82,6 @@ status:
 retention:
   default_local_days: 30
   default_cloud_days: 90
-  auto_archive: true
-  cleanup_after_archive: false
 `;
     fs.writeFileSync(path.join(typeDir, 'type.yaml'), typeYaml);
 

--- a/sdk/js/src/logs/type-registry.ts
+++ b/sdk/js/src/logs/type-registry.ts
@@ -71,8 +71,6 @@ export interface LogTypeDefinition {
   retention?: {
     defaultLocalDays: number | 'forever';
     defaultCloudDays: number | 'forever';
-    autoArchive: boolean;
-    cleanupAfterArchive: boolean;
   };
 
   /** Documentation standards (markdown content) */
@@ -142,8 +140,6 @@ interface RawLogTypeYaml {
   retention?: {
     default_local_days: number | 'forever';
     default_cloud_days: number | 'forever';
-    auto_archive: boolean;
-    cleanup_after_archive: boolean;
   };
 }
 
@@ -258,8 +254,6 @@ function convertYamlToLogType(
       ? {
           defaultLocalDays: raw.retention.default_local_days,
           defaultCloudDays: raw.retention.default_cloud_days,
-          autoArchive: raw.retention.auto_archive,
-          cleanupAfterArchive: raw.retention.cleanup_after_archive,
         }
       : undefined,
     standards,

--- a/templates/logs/audit/type.yaml
+++ b/templates/logs/audit/type.yaml
@@ -83,5 +83,3 @@ severity:
 retention:
   default_local_days: 90
   default_cloud_days: forever
-  auto_archive: true
-  cleanup_after_archive: false

--- a/templates/logs/changelog/type.yaml
+++ b/templates/logs/changelog/type.yaml
@@ -68,5 +68,3 @@ change_type:
 retention:
   default_local_days: forever
   default_cloud_days: forever
-  auto_archive: false
-  cleanup_after_archive: false

--- a/templates/logs/debug/type.yaml
+++ b/templates/logs/debug/type.yaml
@@ -75,5 +75,3 @@ severity:
 retention:
   default_local_days: 14
   default_cloud_days: 30
-  auto_archive: true
-  cleanup_after_archive: true

--- a/templates/logs/deployment/type.yaml
+++ b/templates/logs/deployment/type.yaml
@@ -74,5 +74,3 @@ environment:
 retention:
   default_local_days: 30
   default_cloud_days: forever
-  auto_archive: true
-  cleanup_after_archive: false

--- a/templates/logs/operational/type.yaml
+++ b/templates/logs/operational/type.yaml
@@ -85,5 +85,3 @@ category:
 retention:
   default_local_days: 30
   default_cloud_days: 90
-  auto_archive: true
-  cleanup_after_archive: true

--- a/templates/logs/session/type.yaml
+++ b/templates/logs/session/type.yaml
@@ -67,5 +67,3 @@ status:
 retention:
   default_local_days: 7
   default_cloud_days: forever
-  auto_archive: true
-  cleanup_after_archive: true

--- a/templates/logs/test/type.yaml
+++ b/templates/logs/test/type.yaml
@@ -73,5 +73,3 @@ test_type:
 retention:
   default_local_days: 7
   default_cloud_days: 14
-  auto_archive: true
-  cleanup_after_archive: true

--- a/templates/logs/workflow/type.yaml
+++ b/templates/logs/workflow/type.yaml
@@ -89,5 +89,3 @@ workflow_type:
 retention:
   default_local_days: 30
   default_cloud_days: 90
-  auto_archive: true
-  cleanup_after_archive: true


### PR DESCRIPTION
## Summary
This PR removes automatic archival configuration options from the logs and specs modules, simplifying the retention and archival strategy. The `auto_archive`, `cleanup_after_archive`, `archive_triggers`, and `auto_archive_on` configuration fields have been removed across all packages.

## Key Changes

- **SDK (core)**: Removed `autoArchive` and `cleanupAfterArchive` fields from `LogTypeDefinition` interface and YAML parsing logic
- **CLI**: Updated logs type info command to exclude removed retention fields from output
- **Plugins**: 
  - Removed auto-archive configuration from logs plugin config schema and examples
  - Removed auto-archive configuration from specs plugin config schema and examples
- **Config Examples & Schemas**: Cleaned up all configuration files to remove:
  - `auto_archive` and `cleanup_after_archive` boolean flags
  - `archive_triggers` object with age, size, and status conditions
  - `auto_archive_on` object with event-based triggers
- **Log Type Templates**: Updated all log type YAML files to remove archival configuration
- **Version Bumps**: 
  - Core SDK: 0.7.3 → 0.7.4
  - CLI: 0.4.1 → 0.4.2
  - Logs plugin: 4.0.6 → 4.0.7
  - Spec plugin: 2.0.11 → 2.0.12

## Implementation Details

The removal is comprehensive across the codebase:
- Configuration schemas updated to reflect the simplified structure
- Default configurations no longer include archival settings
- Type definitions and YAML parsing updated to handle the absence of these fields
- All example configurations and templates cleaned up
- Tests updated to reflect the new expected behavior

This simplification reduces configuration complexity while maintaining core retention functionality based on `local_days` and `cloud_days` settings.

https://claude.ai/code/session_01JGWKFg2NzxDiR5yAssRdCZ