### PR TITLE
Fix code review workflow: enable PR comments and remove buggy claude_args

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # Required for gh pr comment
       issues: read
       id-token: write
 
@@ -51,7 +51,9 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
+          # NOTE: claude_args parameter removed due to P1 SDK bug (issue #892, #893)
+          # The claude_args parameter triggers a JSON schema validation failure.
+          # Monitor https://github.com/anthropics/claude-code-action/issues/892 for fix.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # for available options when the bug is resolved.
 


### PR DESCRIPTION
## Summary
Updated the Claude code review GitHub Actions workflow to fix permission issues and work around a known SDK bug that prevents the workflow from executing successfully.

## Key Changes
- **Permission Update**: Changed `pull-requests` permission from `read` to `write` to enable posting review comments via `gh pr comment`
- **Removed claude_args Parameter**: Deleted the `claude_args` configuration that was triggering a JSON schema validation failure in the Claude SDK
- **Added Documentation**: Included comments referencing the upstream SDK issues (#892, #893) and monitoring link for when the bug is resolved

## Implementation Details
The `claude_args` parameter was causing the workflow to fail due to a P1 bug in the Claude SDK. By removing this parameter, the workflow can now execute with default tool permissions. Once the upstream issues are resolved, the `claude_args` parameter can be re-added to provide more granular tool access control.

The `pull-requests: write` permission is necessary for the workflow to post code review comments back to the PR using the GitHub CLI.

https://claude.ai/code/session_01Ef7ovfAoa5xUD1wo1YepQi