### PR TITLE
Rename divergent spec CLI commands and wire agents to CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/cli/src/commands/spec/index.ts
+++ b/cli/src/commands/spec/index.ts
@@ -2,12 +2,12 @@
  * Spec subcommand - Specification management
  *
  * Commands use dashes to mirror plugin naming:
- * CLI: fractary-core spec spec-create
- * Plugin: /fractary-spec:spec-create
+ * CLI: fractary-core spec spec-create-file
+ * Plugin: /fractary-spec:spec-create (AI agent calls spec-create-file internally)
  */
 
 import { Command } from 'commander';
-import { createSpecCreateCommand, createSpecGetCommand, createSpecListCommand, createSpecUpdateCommand, createSpecDeleteCommand, createSpecValidateCommand, createSpecRefineCommand } from './spec';
+import { createSpecCreateFileCommand, createSpecGetCommand, createSpecListCommand, createSpecUpdateCommand, createSpecDeleteCommand, createSpecValidateCheckCommand, createSpecRefineScanCommand } from './spec';
 import { createTemplateListCommand } from './template';
 
 /**
@@ -17,13 +17,13 @@ export function createSpecCommand(): Command {
   const spec = new Command('spec').description('Specification management');
 
   // Spec operations (flat with dashes)
-  spec.addCommand(createSpecCreateCommand());
+  spec.addCommand(createSpecCreateFileCommand());
   spec.addCommand(createSpecGetCommand());
   spec.addCommand(createSpecListCommand());
   spec.addCommand(createSpecUpdateCommand());
   spec.addCommand(createSpecDeleteCommand());
-  spec.addCommand(createSpecValidateCommand());
-  spec.addCommand(createSpecRefineCommand());
+  spec.addCommand(createSpecValidateCheckCommand());
+  spec.addCommand(createSpecRefineScanCommand());
 
   // Template operations (flat with dashes)
   spec.addCommand(createTemplateListCommand());

--- a/cli/src/commands/spec/spec.ts
+++ b/cli/src/commands/spec/spec.ts
@@ -7,9 +7,9 @@ import chalk from 'chalk';
 import { getSpecManager } from '../../sdk/factory';
 import { handleError } from '../../utils/errors';
 
-export function createSpecCreateCommand(): Command {
-  return new Command('spec-create')
-    .description('Create a new specification')
+export function createSpecCreateFileCommand(): Command {
+  return new Command('spec-create-file')
+    .description('Create a new specification file')
     .argument('<title>', 'Specification title')
     .option('--template <type>', 'Specification template (feature, bugfix, refactor)', 'feature')
     .option('--work-id <id>', 'Associated work item ID')
@@ -161,9 +161,9 @@ export function createSpecDeleteCommand(): Command {
     });
 }
 
-export function createSpecValidateCommand(): Command {
-  return new Command('spec-validate')
-    .description('Validate a specification')
+export function createSpecValidateCheckCommand(): Command {
+  return new Command('spec-validate-check')
+    .description('Run structural validation checks on a specification')
     .argument('<id>', 'Specification ID or path')
     .option('--json', 'Output as JSON')
     .action(async (id: string, options) => {
@@ -192,9 +192,9 @@ export function createSpecValidateCommand(): Command {
     });
 }
 
-export function createSpecRefineCommand(): Command {
-  return new Command('spec-refine')
-    .description('Generate refinement questions for a specification')
+export function createSpecRefineScanCommand(): Command {
+  return new Command('spec-refine-scan')
+    .description('Scan a specification for structural gaps and refinement areas')
     .argument('<id>', 'Specification ID or path')
     .option('--json', 'Output as JSON')
     .action(async (id: string, options) => {

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": "./commands/",
   "agents": [

--- a/plugins/spec/agents/spec-creator.md
+++ b/plugins/spec/agents/spec-creator.md
@@ -14,7 +14,7 @@ Your role is to create specifications from conversation context, optionally enri
 </CONTEXT>
 
 <CRITICAL_RULES>
-1. ALWAYS use the spec-generator skill for creation
+1. AI generates spec content from conversation context, then calls CLI to save: `fractary-core spec spec-create-file`
 2. ALWAYS preserve conversation context as primary source
 3. ALWAYS auto-detect work-id from branch if not provided
 4. ALWAYS check for existing specs (idempotent)
@@ -25,11 +25,11 @@ Your role is to create specifications from conversation context, optionally enri
 1. Parse arguments (--work-id, --template, --context, --force)
 2. Auto-detect work-id from branch if not provided
 3. Check for existing specs (skip if exists unless --force)
-4. Invoke fractary-spec:spec-generator skill
-5. Extract conversation context
-6. Fetch issue data if work-id present
-7. Merge contexts and generate spec
-8. Save to /specs directory
+4. [AI] Extract conversation context
+5. [AI] Fetch issue data if work-id present
+6. [AI] Merge contexts and generate spec content
+7. [AI] Select appropriate template based on content
+8. [Deterministic] Save spec via CLI: `fractary-core spec spec-create-file <title> --template <type> [--work-id <id>] --json`
 9. Comment on GitHub issue if work-id present
 </WORKFLOW>
 
@@ -45,17 +45,10 @@ Your role is to create specifications from conversation context, optionally enri
 - Without: `SPEC-{timestamp}-{slug}.md`
 </NAMING>
 
-<SKILL_INVOCATION>
-Invoke the fractary-spec:spec-generator skill with:
-```json
-{
-  "operation": "create",
-  "parameters": {
-    "work_id": "123",
-    "template": null,
-    "context": null,
-    "force": false
-  }
-}
+<CLI_INTEGRATION>
+Save spec to disk via deterministic CLI command:
+```bash
+fractary-core spec spec-create-file "<title>" --template <type> [--work-id <id>] --json
 ```
-</SKILL_INVOCATION>
+Parse the JSON response to get the spec ID and path for subsequent operations.
+</CLI_INTEGRATION>

--- a/plugins/spec/agents/spec-refiner.md
+++ b/plugins/spec/agents/spec-refiner.md
@@ -14,7 +14,7 @@ Your role is to critically review and refine existing specifications through int
 </CONTEXT>
 
 <CRITICAL_RULES>
-1. ALWAYS use the spec-refiner skill for refinement
+1. Use CLI for structural gap scanning (`fractary-core spec spec-refine-scan`), then AI for intelligent question generation
 2. ALWAYS generate meaningful questions (specific, actionable)
 3. ALWAYS post questions to GitHub issue for documentation
 4. ALWAYS make best-effort decisions for unanswered questions
@@ -23,16 +23,17 @@ Your role is to critically review and refine existing specifications through int
 
 <WORKFLOW>
 1. Parse arguments (--work-id, --context)
-2. Invoke fractary-spec:spec-refiner skill
-3. Load spec for work-id
-4. Perform critical analysis
-5. Generate questions and suggestions
-6. Post questions to GitHub issue
-7. Present interactive Q&A to user
-8. Apply improvements based on answers
-9. Make best-effort decisions for unanswered
-10. Add changelog entry
-11. Post completion summary to GitHub
+2. Load spec for work-id
+3. [Deterministic] Scan for structural gaps via CLI: `fractary-core spec spec-refine-scan <id> --json`
+4. Parse scan results (missing sections, empty sections, vague language)
+5. [AI] Perform deeper critical analysis beyond structural gaps
+6. [AI] Generate meaningful, specific questions combining scan results + AI analysis
+7. Post questions to GitHub issue
+8. Present interactive Q&A to user
+9. Apply improvements based on answers
+10. Make best-effort decisions for unanswered
+11. Add changelog entry
+12. Post completion summary to GitHub
 </WORKFLOW>
 
 <ARGUMENTS>
@@ -48,15 +49,10 @@ Avoided questions (generic):
 - "Is this the best approach?"
 </QUESTION_QUALITY>
 
-<SKILL_INVOCATION>
-Invoke the fractary-spec:spec-refiner skill with:
-```json
-{
-  "operation": "refine",
-  "parameters": {
-    "work_id": "255",
-    "context": null
-  }
-}
+<CLI_INTEGRATION>
+Scan for structural gaps via deterministic CLI command:
+```bash
+fractary-core spec spec-refine-scan <id> --json
 ```
-</SKILL_INVOCATION>
+Parse the JSON response for missing sections, empty sections, and vague language indicators. Then perform deeper AI analysis on top of scan results to generate actionable questions.
+</CLI_INTEGRATION>

--- a/plugins/spec/agents/spec-validator.md
+++ b/plugins/spec/agents/spec-validator.md
@@ -14,9 +14,9 @@ Your role is to validate that implementation matches specification requirements.
 </CONTEXT>
 
 <CRITICAL_RULES>
-1. ALWAYS use the spec-validator skill for validation
+1. Use CLI for structural checks (`fractary-core spec spec-validate-check`), then AI for implementation analysis
 2. ALWAYS check requirements coverage, acceptance criteria, files, tests, docs
-3. ALWAYS update spec frontmatter with validation status
+3. ALWAYS update spec frontmatter with validation status via CLI: `fractary-core spec spec-update`
 4. ALWAYS provide actionable feedback for issues
 5. NEVER modify implementation, only report status
 </CRITICAL_RULES>
@@ -24,16 +24,16 @@ Your role is to validate that implementation matches specification requirements.
 <WORKFLOW>
 1. Parse arguments (issue_number, --phase, --context)
 2. If --context provided, apply as additional instructions to workflow
-3. Invoke fractary-spec:spec-validator skill
-3. Load spec for issue
-4. Check requirements coverage
-5. Check acceptance criteria
-6. Check files modified
-7. Check tests added
-8. Check documentation updated
-9. Calculate overall status
-10. Update spec frontmatter
-11. Return validation report
+3. [Deterministic] Run structural checks via CLI: `fractary-core spec spec-validate-check <id> --json`
+4. Parse structural results (score, requirements count, criteria count)
+5. [AI] Check requirements coverage against implementation
+6. [AI] Check acceptance criteria
+7. [AI] Check files modified
+8. [AI] Check tests added
+9. [AI] Check documentation updated
+10. [AI] Calculate overall status combining structural + AI analysis
+11. [Deterministic] Update spec frontmatter via CLI: `fractary-core spec spec-update <id> --status <status>`
+12. Return validation report
 </WORKFLOW>
 
 <ARGUMENTS>
@@ -56,15 +56,15 @@ Your role is to validate that implementation matches specification requirements.
 - **Incomplete**: <80% pass
 </VALIDATION_STATUS>
 
-<SKILL_INVOCATION>
-Invoke the fractary-spec:spec-validator skill with:
-```json
-{
-  "operation": "validate",
-  "parameters": {
-    "issue_number": "123",
-    "phase": null
-  }
-}
+<CLI_INTEGRATION>
+Run structural validation via deterministic CLI command:
+```bash
+fractary-core spec spec-validate-check <id> --json
 ```
-</SKILL_INVOCATION>
+Parse the JSON response for score, requirements count, and criteria count. Then perform deeper AI analysis on top of structural results.
+
+Update spec status via:
+```bash
+fractary-core spec spec-update <id> --status <status>
+```
+</CLI_INTEGRATION>


### PR DESCRIPTION
## Summary
- Renamed 3 deterministic CLI commands to describe their specific function: `spec-create-file`, `spec-validate-check`, `spec-refine-scan`
- Wired 3 AI agents to call renamed CLI commands instead of referencing archived skills
- Split agent workflows to show deterministic CLI operations separate from AI analysis

## Test plan
- [ ] TypeScript compiles without errors
- [ ] `npx fractary-core spec --help` shows renamed commands
- [ ] Agent markdown files reference correct CLI command names
- [ ] No references to archived skill names remain in agent files