### PR TITLE
Bump versions across SDK, CLI, MCP, and plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-core",
         "source": "./plugins/core",
         "description": "Core initialization and configuration for Fractary plugins",
-        "version": "3.4.3",
+        "version": "3.5.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -42,7 +42,7 @@
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",
-        "version": "3.0.6",
+        "version": "3.0.9",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -85,7 +85,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with bulk creation, refinement, and streamlined commands for creating, listing, searching, and updating issues",
-        "version": "3.0.8",
+        "version": "3.0.9",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -128,7 +128,7 @@
         "name": "fractary-file",
         "source": "./plugins/file",
         "description": "Universal file storage operations across R2, S3, and local filesystem with modular handler architecture",
-        "version": "2.0.8",
+        "version": "3.0.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -163,7 +163,7 @@
         "name": "fractary-logs",
         "source": "./plugins/logs",
         "description": "Operational log management with session capture, hybrid retention, archival, search, and analysis",
-        "version": "4.0.8",
+        "version": "4.1.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -210,7 +210,7 @@
         "name": "fractary-status",
         "source": "./plugins/status",
         "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
-        "version": "1.1.11",
+        "version": "1.1.12",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -241,7 +241,7 @@
         "name": "fractary-spec",
         "source": "./plugins/spec",
         "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
-        "version": "2.0.14",
+        "version": "2.0.16",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -277,7 +277,7 @@
         "name": "fractary-docs",
         "source": "./plugins/docs",
         "description": "Type-agnostic documentation system with operation-specific skills and data-driven type context (93% less code duplication)",
-        "version": "3.1.1",
+        "version": "4.0.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -44,7 +44,7 @@
   "author": "Fractary Team",
   "license": "MIT",
   "dependencies": {
-    "@fractary/core": "^0.7.8",
+    "@fractary/core": "^0.7.9",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^11.1.0",

--- a/mcp/server/package.json
+++ b/mcp/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for Fractary Core SDK - universal tool access for work, repo, spec, logs, file, docs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/fractary/core/tree/main/mcp/server#readme",
   "dependencies": {
-    "@fractary/core": "^0.7.7",
+    "@fractary/core": "^0.7.9",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "js-yaml": "^4.1.1",
     "minimatch": "^10.1.1"

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-core",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Core configuration and environment management for Fractary plugins",
   "commands": [
     "./commands/config-init.md",

--- a/plugins/docs/.claude-plugin/plugin.json
+++ b/plugins/docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-docs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Documentation system with per-type skills, archival, refinement, fulfillment validation, and work-linking.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/file/.claude-plugin/plugin.json
+++ b/plugins/file/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-file",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Multi-provider file storage with unified interface (Local, R2, S3, GCS, Google Drive)",
   "commands": "./commands/",
   "agents": [

--- a/plugins/logs/.claude-plugin/plugin.json
+++ b/plugins/logs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-logs",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Log management with per-type skills for Claude auto-discovery. Each log type (session, build, deployment, etc.) has its own skill with synonyms for natural language matching.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-repo",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/spec/.claude-plugin/plugin.json
+++ b/plugins/spec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-spec",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Manage ephemeral specifications tied to work items with lifecycle-based archival",
   "commands": "./commands/",
   "agents": [

--- a/plugins/status/.claude-plugin/plugin.json
+++ b/plugins/status/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-status",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Custom Claude Code status line showing git status, issue numbers, PR numbers, and last prompt",
   "commands": [
     "./commands/install.md",

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-work",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "./commands/",
   "agents": [

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
This release updates versions across the Fractary Core ecosystem, including the SDK, CLI, MCP server, and multiple plugins. The changes reflect bug fixes and minor improvements across the platform.

## Key Changes
- **SDK** (@fractary/core): `0.7.8` → `0.7.9`
- **CLI** (@fractary/core-cli): `0.4.13` → `0.4.14`
- **MCP Server** (@fractary/core-mcp): `0.3.0` → `0.3.1`
- **Marketplace**: `3.3.3` → `3.3.4`

### Plugin Updates
- **fractary-core**: `3.4.3` → `3.5.1` (minor version bump)
- **fractary-docs**: `3.1.1` → `4.0.1` (major version bump)
- **fractary-file**: `2.0.8` → `3.0.1` (major version bump)
- **fractary-logs**: `4.0.8` → `4.1.1` (minor version bump)
- **fractary-repo**: `3.0.6` → `3.0.9` (patch version bump)
- **fractary-spec**: `2.0.14` → `2.0.16` (patch version bump)
- **fractary-status**: `1.1.11` → `1.1.12` (patch version bump)
- **fractary-work**: `3.0.8` → `3.0.9` (patch version bump)

## Implementation Details
- Updated version numbers in both marketplace configuration (`.claude-plugin/marketplace.json`) and individual plugin manifests (`plugins/*/plugin.json`)
- Updated SDK dependency references in CLI and MCP server to use the new SDK version (`^0.7.9`)
- Maintained consistency between marketplace registry and individual plugin version declarations

https://claude.ai/code/session_01XVjjGJe96v1dhjAsipxwh4