### PR TITLE
Add owner and repo configuration fields to repository setup

### DIFF
--- a/plugins/repo/config/repo.example.json
+++ b/plugins/repo/config/repo.example.json
@@ -9,6 +9,10 @@
       "$comment": "Active source control platform: github|gitlab|bitbucket",
 
       "github": {
+        "owner": "your-org",
+        "$comment_owner": "GitHub organization or user that owns the repository",
+        "repo": "your-repo",
+        "$comment_repo": "Repository name",
         "token": "$GITHUB_TOKEN",
         "$comment": "GitHub token from environment variable. Generate at: https://github.com/settings/tokens",
         "$comment_auth": "Token is required for API operations (gh CLI). For git operations, you can use either HTTPS+token or SSH keys.",

--- a/sdk/js/src/config/defaults.ts
+++ b/sdk/js/src/config/defaults.ts
@@ -66,12 +66,14 @@ function getDefaultWorkConfig(options: DefaultConfigOptions): WorkConfig {
  * Get default repository configuration for a platform
  */
 function getDefaultRepoConfig(options: DefaultConfigOptions): RepoConfig {
-  const { repoPlatform = 'github' } = options;
+  const { repoPlatform = 'github', owner = 'your-org', repo = 'your-repo' } = options;
 
   return {
     active_handler: repoPlatform,
     handlers: {
       [repoPlatform]: {
+        owner,
+        repo,
         token: '${GITHUB_TOKEN}',
         api_url: 'https://api.github.com',
       },


### PR DESCRIPTION
## Summary
This PR adds explicit `owner` and `repo` configuration fields to the repository configuration, making it easier for users to specify their GitHub organization/user and repository name during setup.

## Changes
- **repo.example.json**: Added `owner` and `repo` fields to the GitHub configuration section with descriptive comments explaining their purpose
- **defaults.ts**: Updated `getDefaultRepoConfig()` to accept and include `owner` and `repo` options in the default repository configuration

## Details
Previously, users had to manually configure repository ownership details. These changes:
- Provide clear placeholder values (`your-org` and `your-repo`) in the example configuration
- Allow the configuration defaults to be customized with owner and repo information
- Include helpful comments explaining that `owner` refers to a GitHub organization or user
- Maintain backward compatibility by using sensible defaults when options are not provided

https://claude.ai/code/session_01GCNG6KuVoW1Fc9zJpeYXpa