### PR TITLE
Fix RepoManager config resolution and update deprecated CLI references

### DIFF
--- a/docs/guides/new-claude-plugin-framework.md
+++ b/docs/guides/new-claude-plugin-framework.md
@@ -154,7 +154,7 @@ class RepoManager {
 
 Now accessible from:
 - **Plugin** via MCP: `fractary_repo_branch_create` tool
-- **CLI** directly: `fractary repo branch create`
+- **CLI** directly: `fractary-core repo branch-create`
 - **FABER workflows**: Mix repo + work + spec building blocks
 - **n8n workflows**: HTTP calls to SDK endpoints
 - **Custom scripts**: Import and use SDK

--- a/plugins/repo/commands/commit-push-pr-merge.md
+++ b/plugins/repo/commands/commit-push-pr-merge.md
@@ -14,6 +14,8 @@ argument-hint: '[--squash|--merge|--rebase] [--wait-for-checks] [--context "<tex
 
 ## Your task
 
+**IMPORTANT: The CLI binary is `fractary-core`, NOT `fractary`. Always use `fractary-core` as the command prefix.**
+
 **SAFETY WARNING**: This command auto-merges PRs. Only use for solo development, hotfixes, documentation, or repos without branch protection requiring reviews.
 
 Use the **Bash** tool for each step below. Do NOT use the Skill tool.

--- a/plugins/repo/commands/commit-push-pr.md
+++ b/plugins/repo/commands/commit-push-pr.md
@@ -14,6 +14,8 @@ argument-hint: '[--context "<text>"]'
 
 ## Your task
 
+**IMPORTANT: The CLI binary is `fractary-core`, NOT `fractary`. Always use `fractary-core` as the command prefix.**
+
 Use the **Bash** tool for each step below. Do NOT use the Skill tool.
 
 Based on the above changes:

--- a/plugins/repo/commands/commit-push.md
+++ b/plugins/repo/commands/commit-push.md
@@ -14,6 +14,8 @@ argument-hint: '[--context "<text>"]'
 
 ## Your task
 
+**IMPORTANT: The CLI binary is `fractary-core`, NOT `fractary`. Always use `fractary-core` as the command prefix.**
+
 Use the **Bash** tool for each step below. Do NOT use the Skill tool.
 
 Based on the above changes:

--- a/plugins/work/README.md
+++ b/plugins/work/README.md
@@ -77,17 +77,17 @@ Layer 4: Scripts (Deterministic Operations)
 
 ### Fractary CLI (Required)
 
-The work plugin requires the Fractary CLI for core operations:
+The work plugin requires the Fractary Core CLI for core operations:
 
 ```bash
-# Install Fractary CLI globally
-npm install -g @fractary/cli
+# Install Fractary Core CLI globally
+npm install -g @fractary/core-cli
 
 # Verify installation
-fractary --version
+fractary-core --version
 ```
 
-**Minimum CLI Version:** `@fractary/cli >= 0.3.0`
+**Minimum CLI Version:** `@fractary/core-cli >= 0.4.0`
 
 ### Additional Dependencies
 

--- a/plugins/work/skills/handler-work-tracker-github/SKILL.md
+++ b/plugins/work/skills/handler-work-tracker-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handler-work-tracker-github
-description: "[DEPRECATED] GitHub Issues handler - Use Fractary CLI instead"
+description: "[DEPRECATED] GitHub Issues handler - Use Fractary Core CLI instead"
 model: haiku
 handler_type: work-tracker
 platform: github
@@ -9,14 +9,14 @@ deprecated: true
 
 # GitHub Work Tracker Handler
 
-> **⚠️ DEPRECATED**: This handler is deprecated. Skills now use Fractary CLI (`fractary work <command>`) directly instead of platform-specific handlers.
+> **⚠️ DEPRECATED**: This handler is deprecated. Skills now use Fractary Core CLI (`fractary-core work <command>`) directly instead of platform-specific handlers.
 >
 > **Migration**: See `specs/WORK-00356-implement-faber-cli-work-commands.md` for the CLI migration plan.
 
 <CONTEXT>
 You are the GitHub Issues handler for the work plugin. This handler is **DEPRECATED** as of the CLI migration.
 
-**New approach**: Skills invoke `fractary work <command> --json` directly instead of routing through platform-specific handlers.
+**New approach**: Skills invoke `fractary-core work <command> --json` directly instead of routing through platform-specific handlers.
 
 **Why deprecated**:
 1. CLI provides platform abstraction at a lower level
@@ -27,7 +27,7 @@ You are the GitHub Issues handler for the work plugin. This handler is **DEPRECA
 
 <CRITICAL_RULES>
 1. **DEPRECATED** - Do not use this handler for new implementations
-2. Skills should use Fractary CLI directly: `fractary work <command> --json`
+2. Skills should use Fractary Core CLI directly: `fractary-core work <command> --json`
 3. Existing scripts retained for backward compatibility only
 4. No new features will be added to this handler
 </CRITICAL_RULES>
@@ -41,7 +41,7 @@ Skill → Handler → scripts/*.sh → GitHub API
 
 ### After (CLI-based)
 ```
-Skill → Fractary CLI → GitHub API
+Skill → Fractary Core CLI → GitHub API
 ```
 
 ### Example Migration
@@ -55,25 +55,25 @@ Skill → Fractary CLI → GitHub API
 **After (recommended):**
 ```bash
 # Skill invokes CLI directly
-fractary work issue fetch 123 --json
+fractary-core work issue fetch 123 --json
 ```
 
 ## CLI Command Mapping
 
 | Handler Operation | CLI Command | Status |
 |-------------------|-------------|--------|
-| fetch-issue | `fractary work issue fetch <n>` | ✅ Available |
-| create-issue | `fractary work issue create` | ✅ Available |
-| update-issue | `fractary work issue update <n>` | ✅ Available |
-| close-issue | `fractary work issue close <n>` | ✅ Available |
-| reopen-issue | `fractary work issue reopen <n>` | ❌ Missing |
-| list-issues | `fractary work issue search` | ✅ Available |
-| create-comment | `fractary work comment create <n>` | ✅ Available |
-| list-comments | `fractary work comment list <n>` | ✅ Available |
-| add-label | `fractary work label add <n>` | ✅ Available |
-| remove-label | `fractary work label remove <n>` | ✅ Available |
-| assign-issue | `fractary work issue assign <n>` | ❌ Missing |
-| classify-issue | `fractary work issue classify <n>` | ❌ Missing |
+| fetch-issue | `fractary-core work issue fetch <n>` | ✅ Available |
+| create-issue | `fractary-core work issue create` | ✅ Available |
+| update-issue | `fractary-core work issue update <n>` | ✅ Available |
+| close-issue | `fractary-core work issue close <n>` | ✅ Available |
+| reopen-issue | `fractary-core work issue reopen <n>` | ❌ Missing |
+| list-issues | `fractary-core work issue search` | ✅ Available |
+| create-comment | `fractary-core work comment create <n>` | ✅ Available |
+| list-comments | `fractary-core work comment list <n>` | ✅ Available |
+| add-label | `fractary-core work label add <n>` | ✅ Available |
+| remove-label | `fractary-core work label remove <n>` | ✅ Available |
+| assign-issue | `fractary-core work issue assign <n>` | ❌ Missing |
+| classify-issue | `fractary-core work issue classify <n>` | ❌ Missing |
 
 ## Backward Compatibility
 

--- a/plugins/work/skills/handler-work-tracker-jira/SKILL.md
+++ b/plugins/work/skills/handler-work-tracker-jira/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handler-work-tracker-jira
-description: "[DEPRECATED] Jira Cloud handler - Use Fractary CLI instead"
+description: "[DEPRECATED] Jira Cloud handler - Use Fractary Core CLI instead"
 model: haiku
 handler_type: work-tracker
 platform: jira
@@ -9,14 +9,14 @@ deprecated: true
 
 # Jira Work Tracker Handler
 
-> **⚠️ DEPRECATED**: This handler is deprecated. Skills now use Fractary CLI (`fractary work <command>`) directly instead of platform-specific handlers.
+> **⚠️ DEPRECATED**: This handler is deprecated. Skills now use Fractary Core CLI (`fractary-core work <command>`) directly instead of platform-specific handlers.
 >
 > **Migration**: See `specs/WORK-00356-implement-faber-cli-work-commands.md` for the CLI migration plan.
 
 <CONTEXT>
 You are the Jira Cloud handler for the work plugin. This handler is **DEPRECATED** as of the CLI migration.
 
-**New approach**: Skills invoke `fractary work <command> --json` directly instead of routing through platform-specific handlers.
+**New approach**: Skills invoke `fractary-core work <command> --json` directly instead of routing through platform-specific handlers.
 
 **Why deprecated**:
 1. CLI provides platform abstraction at a lower level
@@ -27,7 +27,7 @@ You are the Jira Cloud handler for the work plugin. This handler is **DEPRECATED
 
 <CRITICAL_RULES>
 1. **DEPRECATED** - Do not use this handler for new implementations
-2. Skills should use Fractary CLI directly: `fractary work <command> --json`
+2. Skills should use Fractary Core CLI directly: `fractary-core work <command> --json`
 3. Existing scripts retained for backward compatibility only
 4. No new features will be added to this handler
 </CRITICAL_RULES>
@@ -41,7 +41,7 @@ Skill → Handler → scripts/*.sh → Jira REST API
 
 ### After (CLI-based)
 ```
-Skill → Fractary CLI → Jira REST API
+Skill → Fractary Core CLI → Jira REST API
 ```
 
 ### Example Migration
@@ -55,25 +55,25 @@ Skill → Fractary CLI → Jira REST API
 **After (recommended):**
 ```bash
 # Skill invokes CLI directly
-fractary work issue fetch PROJ-123 --json
+fractary-core work issue fetch PROJ-123 --json
 ```
 
 ## CLI Command Mapping
 
 | Handler Operation | CLI Command | Status |
 |-------------------|-------------|--------|
-| fetch-issue | `fractary work issue fetch <key>` | ✅ Available |
-| create-issue | `fractary work issue create` | ✅ Available |
-| update-issue | `fractary work issue update <key>` | ✅ Available |
-| close-issue | `fractary work issue close <key>` | ✅ Available |
-| reopen-issue | `fractary work issue reopen <key>` | ❌ Missing |
-| list-issues | `fractary work issue search` | ✅ Available |
-| create-comment | `fractary work comment create <key>` | ✅ Available |
-| list-comments | `fractary work comment list <key>` | ✅ Available |
-| add-label | `fractary work label add <key>` | ✅ Available |
-| remove-label | `fractary work label remove <key>` | ✅ Available |
-| assign-issue | `fractary work issue assign <key>` | ❌ Missing |
-| classify-issue | `fractary work issue classify <key>` | ❌ Missing |
+| fetch-issue | `fractary-core work issue fetch <key>` | ✅ Available |
+| create-issue | `fractary-core work issue create` | ✅ Available |
+| update-issue | `fractary-core work issue update <key>` | ✅ Available |
+| close-issue | `fractary-core work issue close <key>` | ✅ Available |
+| reopen-issue | `fractary-core work issue reopen <key>` | ❌ Missing |
+| list-issues | `fractary-core work issue search` | ✅ Available |
+| create-comment | `fractary-core work comment create <key>` | ✅ Available |
+| list-comments | `fractary-core work comment list <key>` | ✅ Available |
+| add-label | `fractary-core work label add <key>` | ✅ Available |
+| remove-label | `fractary-core work label remove <key>` | ✅ Available |
+| assign-issue | `fractary-core work issue assign <key>` | ❌ Missing |
+| classify-issue | `fractary-core work issue classify <key>` | ❌ Missing |
 
 ## Backward Compatibility
 

--- a/plugins/work/skills/handler-work-tracker-linear/SKILL.md
+++ b/plugins/work/skills/handler-work-tracker-linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handler-work-tracker-linear
-description: "[DEPRECATED] Linear handler - Use Fractary CLI instead"
+description: "[DEPRECATED] Linear handler - Use Fractary Core CLI instead"
 model: haiku
 handler_type: work-tracker
 platform: linear
@@ -9,14 +9,14 @@ deprecated: true
 
 # Linear Work Tracker Handler
 
-> **⚠️ DEPRECATED**: This handler is deprecated. Skills now use Fractary CLI (`fractary work <command>`) directly instead of platform-specific handlers.
+> **⚠️ DEPRECATED**: This handler is deprecated. Skills now use Fractary Core CLI (`fractary-core work <command>`) directly instead of platform-specific handlers.
 >
 > **Migration**: See `specs/WORK-00356-implement-faber-cli-work-commands.md` for the CLI migration plan.
 
 <CONTEXT>
 You are the Linear handler for the work plugin. This handler is **DEPRECATED** as of the CLI migration.
 
-**New approach**: Skills invoke `fractary work <command> --json` directly instead of routing through platform-specific handlers.
+**New approach**: Skills invoke `fractary-core work <command> --json` directly instead of routing through platform-specific handlers.
 
 **Why deprecated**:
 1. CLI provides platform abstraction at a lower level
@@ -27,7 +27,7 @@ You are the Linear handler for the work plugin. This handler is **DEPRECATED** a
 
 <CRITICAL_RULES>
 1. **DEPRECATED** - Do not use this handler for new implementations
-2. Skills should use Fractary CLI directly: `fractary work <command> --json`
+2. Skills should use Fractary Core CLI directly: `fractary-core work <command> --json`
 3. Existing scripts retained for backward compatibility only
 4. No new features will be added to this handler
 </CRITICAL_RULES>
@@ -41,7 +41,7 @@ Skill → Handler → scripts/*.sh → Linear GraphQL API
 
 ### After (CLI-based)
 ```
-Skill → Fractary CLI → Linear GraphQL API
+Skill → Fractary Core CLI → Linear GraphQL API
 ```
 
 ### Example Migration
@@ -55,25 +55,25 @@ Skill → Fractary CLI → Linear GraphQL API
 **After (recommended):**
 ```bash
 # Skill invokes CLI directly
-fractary work issue fetch TEAM-123 --json
+fractary-core work issue fetch TEAM-123 --json
 ```
 
 ## CLI Command Mapping
 
 | Handler Operation | CLI Command | Status |
 |-------------------|-------------|--------|
-| fetch-issue | `fractary work issue fetch <id>` | ✅ Available |
-| create-issue | `fractary work issue create` | ✅ Available |
-| update-issue | `fractary work issue update <id>` | ✅ Available |
-| close-issue | `fractary work issue close <id>` | ✅ Available |
-| reopen-issue | `fractary work issue reopen <id>` | ❌ Missing |
-| list-issues | `fractary work issue search` | ✅ Available |
-| create-comment | `fractary work comment create <id>` | ✅ Available |
-| list-comments | `fractary work comment list <id>` | ✅ Available |
-| add-label | `fractary work label add <id>` | ✅ Available |
-| remove-label | `fractary work label remove <id>` | ✅ Available |
-| assign-issue | `fractary work issue assign <id>` | ❌ Missing |
-| classify-issue | `fractary work issue classify <id>` | ❌ Missing |
+| fetch-issue | `fractary-core work issue fetch <id>` | ✅ Available |
+| create-issue | `fractary-core work issue create` | ✅ Available |
+| update-issue | `fractary-core work issue update <id>` | ✅ Available |
+| close-issue | `fractary-core work issue close <id>` | ✅ Available |
+| reopen-issue | `fractary-core work issue reopen <id>` | ❌ Missing |
+| list-issues | `fractary-core work issue search` | ✅ Available |
+| create-comment | `fractary-core work comment create <id>` | ✅ Available |
+| list-comments | `fractary-core work comment list <id>` | ✅ Available |
+| add-label | `fractary-core work label add <id>` | ✅ Available |
+| remove-label | `fractary-core work label remove <id>` | ✅ Available |
+| assign-issue | `fractary-core work issue assign <id>` | ❌ Missing |
+| classify-issue | `fractary-core work issue classify <id>` | ❌ Missing |
 
 ## Backward Compatibility
 

--- a/plugins/work/skills/work-initializer/SKILL.md
+++ b/plugins/work/skills/work-initializer/SKILL.md
@@ -11,11 +11,11 @@ You are the work-initializer skill responsible for setting up the Fractary Work 
 
 **NOTE**: The Fractary CLI `work init` command is not yet implemented. This skill currently returns NOT_IMPLEMENTED errors. See `specs/WORK-00356-1-missing-cli-work-commands.md` for tracking.
 
-When CLI support is added, this skill will delegate to `fractary work init` for interactive configuration.
+When CLI support is added, this skill will delegate to `fractary-core work init` for interactive configuration.
 </CONTEXT>
 
 <CRITICAL_RULES>
-1. CLI command `fractary work init` is NOT YET AVAILABLE
+1. CLI command `fractary-core work init` is NOT YET AVAILABLE
 2. ALWAYS return NOT_IMPLEMENTED error until CLI is available
 3. ALWAYS output start/end messages for visibility
 4. NEVER use legacy scripts for initialization
@@ -57,8 +57,8 @@ You receive requests from work-manager agent with:
 
 ```bash
 # Future CLI command (when implemented)
-fractary work init --platform github --yes
-fractary work init --platform jira --interactive
+fractary-core work init --platform github --yes
+fractary-core work init --platform jira --interactive
 ```
 
 **Status**: ❌ Not yet implemented in `@fractary/cli`
@@ -177,7 +177,7 @@ See: WORK-00356-1-missing-cli-work-commands.md
 
 ## Dependencies
 
-- `@fractary/cli >= 0.4.0` (future) - Fractary CLI with init command
+- `@fractary/core-cli >= 0.4.0` (future) - Fractary Core CLI with init command
 - work-manager agent for routing
 
 ## Migration Notes
@@ -187,7 +187,7 @@ See: WORK-00356-1-missing-cli-work-commands.md
 
 ### CLI Implementation Tracking
 - Spec: `specs/WORK-00356-1-missing-cli-work-commands.md`
-- Required CLI command: `fractary work init [options]`
+- Required CLI command: `fractary-core work init [options]`
 
 ### Configuration Path
 - Config location: `.fractary/config.yaml`

--- a/sdk/js/src/work/manager.ts
+++ b/sdk/js/src/work/manager.ts
@@ -55,7 +55,7 @@ export class WorkManager {
     const raw = loadWorkConfig(findProjectRoot());
     if (!raw) {
       throw new ConfigurationError(
-        'Work configuration not found. Run "fractary work init" to set up.'
+        'Work configuration not found. Run "fractary-core work init" to set up.'
       );
     }
 


### PR DESCRIPTION
## Summary

- Fix `Unknown repo platform: undefined` error that broke all `fractary-core repo` commands
- Add explicit CLI binary warnings to prevent haiku from calling wrong binary
- Clean up deprecated `fractary` CLI references across active files

## Changes

### Bug fix: RepoManager config resolution (`sdk/js/src/repo/manager.ts`)
- Added `loadConfig()` method that transforms the YAML handler-based config (`active_handler` + `handlers`) into the flat SDK `RepoConfig` format (`platform` + `owner` + `repo` + `token`)
- This matches the conversion pattern `WorkManager` already had — `RepoManager` was missing it
- Also maps `defaults.environments` and `defaults.default_environment` to SDK format

### Haiku binary name fix (3 files)
- Added `**IMPORTANT: The CLI binary is fractary-core, NOT fractary**` to `commit-push.md`, `commit-push-pr.md`, `commit-push-pr-merge.md`

### Deprecated reference cleanup (7 files)
- `sdk/js/src/work/manager.ts` — error message
- `docs/guides/new-claude-plugin-framework.md` — CLI example
- `plugins/work/README.md` — install instructions, package name, version
- `plugins/work/skills/work-initializer/SKILL.md` — all CLI references
- `plugins/work/skills/handler-work-tracker-{github,jira,linear}/SKILL.md` — all CLI references

## Test plan
- [x] SDK compiles cleanly (`tsc --noEmit`)
- [x] SDK builds (`npm run build`)
- [x] CLI builds (`npm run build`)
- [x] `fractary-core repo branch-list` works with YAML config format

🤖 Generated with [Claude Code](https://claude.com/claude-code)