### PR TITLE
Fix: gh/git CLI hangs and GITHUB_TOKEN warning spam

### DIFF
--- a/sdk/js/src/common/yaml-config.ts
+++ b/sdk/js/src/common/yaml-config.ts
@@ -476,6 +476,8 @@ export function substituteEnvVars(content: string, warnMissing = true): string {
   // Maximum length for default values to prevent abuse
   const MAX_DEFAULT_LENGTH = 1000;
 
+  const warnedVars = new Set<string>();
+
   return content.replace(
     /\$\{([A-Z_][A-Z0-9_]*)(:-([^}]+))?\}/g,
     (match, varName, _, defaultValue) => {
@@ -504,7 +506,8 @@ export function substituteEnvVars(content: string, warnMissing = true): string {
         return defaultValue;
       }
 
-      if (warnMissing) {
+      if (warnMissing && !warnedVars.has(varName)) {
+        warnedVars.add(varName);
         console.warn(
           `Warning: Environment variable ${varName} not set. ` +
           `Using placeholder value.`

--- a/sdk/js/src/repo/git.ts
+++ b/sdk/js/src/repo/git.ts
@@ -27,6 +27,7 @@ function git(args: string, cwd?: string): string {
     encoding: 'utf-8',
     cwd: cwd || findProjectRoot(),
     maxBuffer: 10 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'pipe'],
   };
 
   try {

--- a/sdk/js/src/repo/providers/github.ts
+++ b/sdk/js/src/repo/providers/github.ts
@@ -29,6 +29,7 @@ function gh<T>(args: string, cwd?: string): T {
     encoding: 'utf-8' as const,
     cwd: cwd || findProjectRoot(),
     maxBuffer: 10 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'pipe'] as const,
   };
 
   try {
@@ -49,6 +50,7 @@ function ghRaw(args: string, cwd?: string): string {
     encoding: 'utf-8' as const,
     cwd: cwd || findProjectRoot(),
     maxBuffer: 10 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'pipe'] as const,
   };
 
   try {


### PR DESCRIPTION
Fixes hanging in pr-merge and duplicate GITHUB_TOKEN warnings by:
- Adding stdio: 'pipe' to execSync calls in github.ts and git.ts
- Deduplicating env var warnings in yaml-config.ts using a Set