### PR TITLE
feat: add environment management commands

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core-cli",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "@fractary/core": "^0.4.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/core/agents/config-initializer.md
+++ b/plugins/core/agents/config-initializer.md
@@ -7,7 +7,7 @@ description: |
   Smart detection: auto-detects platforms and project info, presents guesses for user confirmation via interactive prompts.
 color: orange
 model: claude-haiku-4-5
-allowed-tools: Bash(git remote *), Bash(fractary-core config *), Bash(mkdir *), Bash(grep *), Bash(touch *), Bash(cat *), Read(*), Edit(*), Write(*), Glob(*), AskUserQuestion(*)
+allowed-tools: Bash(git remote *), Bash(fractary-core config *), Bash(mkdir *), Bash(grep *), Bash(touch *), Bash(cat *), Read(*), Edit(*), Write(*), Glob(*), AskUserQuestion(*), Bash(fractary-core config env-init:*), Bash(fractary-core config env-section-write:*)
 ---
 
 <CONTEXT>
@@ -144,9 +144,26 @@ mkdir -p logs/templates
 mkdir -p docs
 mkdir -p docs/templates
 mkdir -p docs/specs
+
+# Initialize env directory and example file
+fractary-core config env-init
+
+# Write core plugin's managed section to .env.example
+fractary-core config env-section-write fractary-core \
+  --file .fractary/env/.env.example \
+  --set "GITHUB_TOKEN=ghp_your_token_here" \
+  --set "# AWS_ACCESS_KEY_ID=" \
+  --set "# AWS_SECRET_ACCESS_KEY=" \
+  --set "# AWS_DEFAULT_REGION=us-east-1" \
+  --set "# JIRA_URL=" \
+  --set "# JIRA_EMAIL=" \
+  --set "# JIRA_TOKEN=" \
+  --set "# LINEAR_API_KEY="
 ```
 
-## 5. Create/Update .fractary/.gitignore
+## 5. Create/Update .gitignore
+
+The `env-init` command handles `.fractary/.gitignore` for env files.
 
 Ensure the project root `.gitignore` has managed sections for archive directories:
 
@@ -213,7 +230,7 @@ Values used:
 
 Next steps:
 1. Review config: fractary-core config show
-2. Set credentials in .env file
+2. Set credentials in .fractary/env/.env (copy from .fractary/env/.env.example)
 3. Test: /fractary-work:issue-list
 4. For updates: /fractary-core:config-update --context "description of changes"
 ```

--- a/plugins/core/agents/env-switcher.md
+++ b/plugins/core/agents/env-switcher.md
@@ -13,9 +13,11 @@ You are the env-switcher agent for Fractary Core.
 Your role is to switch the active environment mid-session by invoking the CLI to load credentials from environment-specific .env files.
 
 This is essential for workflows like FABR where you move through phases targeting different environments:
-- **Frame/Architect/Build**: Local development (default .env)
-- **Evaluate**: Test environment (.env.test)
-- **Release**: Production environment (.env.prod)
+- **Frame/Architect/Build**: Local development (default .fractary/env/.env)
+- **Evaluate**: Test environment (.fractary/env/.env.test)
+- **Release**: Production environment (.fractary/env/.env.prod)
+
+Env files are resolved from `.fractary/env/` (standard) with fallback to project root (legacy).
 </CONTEXT>
 
 <CRITICAL_RULES>
@@ -66,7 +68,7 @@ fractary-core config env-show
 
 ```
 Environment switched to: {environment}
-Credentials loaded from: .env → .env.{environment} → .env.local
+Credentials loaded from: .fractary/env/.env → .fractary/env/.env.{environment} → .fractary/env/.env.local
 
 Commands will now use {environment} credentials.
 To switch back: /fractary-core:env-switch <name>

--- a/plugins/core/commands/env-init.md
+++ b/plugins/core/commands/env-init.md
@@ -1,0 +1,18 @@
+---
+name: fractary-core:env-init
+allowed-tools: Bash(fractary-core config env-init:*)
+description: Initialize .fractary/env/ directory with template files
+model: claude-haiku-4-5
+argument-hint: '[--context "<text>"]'
+---
+
+## Your task
+
+Initialize the `.fractary/env/` directory using the CLI command `fractary-core config env-init`.
+
+This creates the `.fractary/env/` directory, a `.env.example` template, and updates `.fractary/.gitignore` to exclude env files.
+
+Examples:
+- Initialize: `fractary-core config env-init`
+
+You have the capability to call multiple tools in a single response. Execute the init operation in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/plugins/core/commands/env-list.md
+++ b/plugins/core/commands/env-list.md
@@ -10,7 +10,7 @@ argument-hint: '[--context "<text>"]'
 
 List available environments using the CLI command `fractary-core config env-list`.
 
-Shows all `.env` files found in the project root and indicates the currently active environment.
+Shows all `.env` files found in `.fractary/env/` (standard) and project root (legacy), indicating the currently active environment and file location.
 
 Examples:
 - List environments: `fractary-core config env-list`

--- a/plugins/core/commands/env-section-read.md
+++ b/plugins/core/commands/env-section-read.md
@@ -1,0 +1,20 @@
+---
+name: fractary-core:env-section-read
+allowed-tools: Bash(fractary-core config env-section-read:*)
+description: Read a plugin's managed section from an env file
+model: claude-haiku-4-5
+argument-hint: '<plugin> [--env <name>] [--file <path>]'
+---
+
+## Your task
+
+Read a plugin's managed section from an env file using the CLI command `fractary-core config env-section-read`.
+
+Displays the KEY=VALUE pairs owned by the specified plugin within the env file.
+
+Examples:
+- Read core section from default .env: `fractary-core config env-section-read fractary-core`
+- Read from test env: `fractary-core config env-section-read fractary-core --env test`
+- Read from explicit file: `fractary-core config env-section-read fractary-core --file .fractary/env/.env.prod`
+
+Parse the arguments from $ARGUMENTS and execute the appropriate command. Do not use any other tools or do anything else.

--- a/plugins/core/commands/env-section-write.md
+++ b/plugins/core/commands/env-section-write.md
@@ -1,0 +1,20 @@
+---
+name: fractary-core:env-section-write
+allowed-tools: Bash(fractary-core config env-section-write:*)
+description: Write a plugin's managed section to an env file
+model: claude-haiku-4-5
+argument-hint: '<plugin> [--env <name>] [--file <path>] --set KEY=VALUE [--set KEY=VALUE ...]'
+---
+
+## Your task
+
+Write/update a plugin's managed section in an env file using the CLI command `fractary-core config env-section-write`.
+
+Creates or updates the managed section for the specified plugin. Other plugins' sections are preserved untouched.
+
+Examples:
+- Write to test env: `fractary-core config env-section-write fractary-core --env test --set "GITHUB_TOKEN=ghp_abc123"`
+- Write multiple vars: `fractary-core config env-section-write fractary-core --env prod --set "GITHUB_TOKEN=ghp_abc" --set "AWS_REGION=us-east-1"`
+- Write to explicit file: `fractary-core config env-section-write fractary-core --file .fractary/env/.env.example --set "GITHUB_TOKEN=ghp_your_token_here"`
+
+Parse the arguments from $ARGUMENTS and execute the appropriate command. Do not use any other tools or do anything else.

--- a/plugins/core/commands/env-switch.md
+++ b/plugins/core/commands/env-switch.md
@@ -1,6 +1,6 @@
 ---
 name: fractary-core:env-switch
-description: Switch to a different environment (test, staging, prod) for credentials
+description: Switch to a different environment (test, staging, prod) for credentials from .fractary/env/
 allowed-tools: Task(fractary-core:env-switcher)
 model: claude-haiku-4-5
 argument-hint: '<environment> [--clear] [--context "<text>"]'

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core",
-      "version": "0.7.20",
+      "version": "0.7.21",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/src/config/index.ts
+++ b/sdk/js/src/config/index.ts
@@ -13,9 +13,16 @@ export {
   clearEnv,
   loadConfig,
   loadConfigSync,
+  getEnvDir,
+  ensureEnvDir,
+  listEnvFiles,
+  resolveEnvFile,
+  readManagedSection,
+  writeManagedSection,
   type LoadedConfig,
   type LoadConfigOptions,
   type ExtractedGitHubConfig,
+  type EnvFileInfo,
 } from './loader';
 
 // Re-export common yaml-config utilities

--- a/sdk/js/src/work/providers/github.ts
+++ b/sdk/js/src/work/providers/github.ts
@@ -128,7 +128,6 @@ export class GitHubWorkProvider implements WorkProvider {
         throw new IssueCreateError(error.stderr);
       }
       const err = error as { status?: number; stderr?: Buffer | string };
-      const exitCode = err.status || 1;
       const stderr = err.stderr?.toString() || '';
       if (stderr.includes('authentication') || stderr.includes('auth')) {
         throw new AuthenticationError('github', 'GitHub authentication failed. Run "gh auth login"');


### PR DESCRIPTION
## Summary
Add three new environment management commands to the CLI:
- env-init: Initialize .fractary/env/ directory
- env-section-read: Read a plugin's managed section from an env file
- env-section-write: Write a plugin's managed section to an env file

## Changes
- Version bump to 0.4.25
- Extended config command documentation with new env subcommands
- Updated environment management utilities and config loading logic
- Enhanced work provider (GitHub) integration

## Test plan
- [ ] Verify new env commands are accessible via CLI
- [ ] Test env-init creates directory structure correctly
- [ ] Test env-section-read/write operations work as expected
- [ ] Verify existing env functionality still works (env-list, env-show, env-switch)
- [ ] Run existing test suite to ensure no regressions