### PR TITLE
chore: bump CLI to 0.4.26 and SDK to 0.7.22

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core-cli",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "license": "MIT",
       "dependencies": {
         "@fractary/core": "^0.4.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core",
-      "version": "0.7.21",
+      "version": "0.7.22",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump versions for CLI and SDK packages.