### PR TITLE
chore: bump CLI to 0.4.27 and SDK to 0.7.23

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core-cli",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "MIT",
       "dependencies": {
         "@fractary/core": "^0.4.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core-cli",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "CLI for Fractary Core SDK - work tracking, repository management, specifications, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/core",
-      "version": "0.7.22",
+      "version": "0.7.23",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/core",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Fractary Core SDK - Primitive operations for work tracking, repository management, logging, file storage, and documentation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.4.26 to 0.4.27
- Bump SDK version from 0.7.22 to 0.7.23

## Changes
- Updated cli/package.json and cli/package-lock.json
- Updated sdk/js/package.json and sdk/js/package-lock.json