### PR TITLE
chore: bump fractary-repo to 3.0.18, fractary-work to 3.0.20, and marketplace to 3.3.17

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready core plugins powered by Claude Code agents, commands, skills and hooks.",
-      "version": "3.3.16",
+      "version": "3.3.17",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -50,7 +50,7 @@
         "name": "fractary-repo",
         "source": "./plugins/repo",
         "description": "Universal source control operations across GitHub, GitLab, and Bitbucket with modular handler architecture",
-        "version": "3.0.17",
+        "version": "3.0.18",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -93,7 +93,7 @@
         "name": "fractary-work",
         "source": "./plugins/work",
         "description": "GitHub Issues management with bulk creation, refinement, and streamlined commands for creating, listing, searching, and updating issues",
-        "version": "3.0.19",
+        "version": "3.0.20",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/repo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-repo",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "Source control operations across GitHub, GitLab, Bitbucket, etc.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-work",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "Work item management across GitHub, Jira, Linear, etc.",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary
- Bump fractary-repo plugin from 3.0.17 to 3.0.18
- Bump fractary-work plugin from 3.0.19 to 3.0.20
- Bump marketplace from 3.3.16 to 3.3.17

## Changes
- Updated .claude-plugin/marketplace.json
- Updated plugins/repo/.claude-plugin/plugin.json
- Updated plugins/work/.claude-plugin/plugin.json